### PR TITLE
Add `skiareshape` and `skiareshapegl` elements.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2360,7 +2360,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps 7.0.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3137,6 +3137,7 @@ dependencies = [
  "gstreamer-base",
  "gstreamer-check",
  "gstreamer-editing-services",
+ "gstreamer-gl",
  "gstreamer-video",
  "skia-safe",
  "tracing",
@@ -4862,7 +4863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6053,7 +6054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -6226,7 +6227,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6701,7 +6702,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7625,7 +7626,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8614,7 +8615,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,6 +2364,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94edab108827d67608095e269cf862e60d920f144a5026d3dbcfd8b877fb404"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glib"
 version = "0.21.0"
 source = "git+https://github.com/gtk-rs/gtk-rs-core?branch=main#8523f56e8fe2c0aad8baac4a7b12231476458e81"
@@ -3132,6 +3152,7 @@ dependencies = [
 name = "gst-plugin-skia"
 version = "0.14.0-alpha.1"
 dependencies = [
+ "gl",
  "gst-plugin-version-helper",
  "gstreamer",
  "gstreamer-base",
@@ -4805,6 +4826,12 @@ checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kstring"

--- a/cargo_wrapper.py
+++ b/cargo_wrapper.py
@@ -24,7 +24,7 @@ PARSER.add_argument('--packages', nargs='+', default=[])
 PARSER.add_argument('--examples', nargs='+', default=[])
 PARSER.add_argument('--lib-suffixes', nargs='+', default=[])
 PARSER.add_argument('--exe-suffix')
-PARSER.add_argument('--depfile')
+PARSER.add_argument('--depfile', type=P)
 PARSER.add_argument('--disable-doc', action='store_true', default=False)
 
 
@@ -73,7 +73,7 @@ def generate_depfile_for(fpath):
 if __name__ == '__main__':
     opts = PARSER.parse_args()
     logdir = opts.root_dir / 'meson-logs'
-    logfile_path = logdir / f'{opts.src_dir.name}-cargo-wrapper.log'
+    logfile_path = logdir / f'{opts.depfile.name.replace('.dep', '')}-cargo-wrapper.log'
     logfile = open(logfile_path, mode='w', buffering=1, encoding='utf-8')
 
     print(opts, file=logfile)
@@ -130,9 +130,12 @@ if __name__ == '__main__':
         cargo_cmd.extend(['--bin', opts.bin.name])
     else:
         if not opts.examples:
-            cargo_cmd.extend(
-                ['--prefix', opts.prefix, '--libdir', opts.prefix / opts.libdir]
-            )
+            cargo_cmd.extend([
+                '--prefix',
+                opts.prefix,
+                '--libdir',
+                opts.prefix / opts.libdir,
+            ])
         for p in opts.packages:
             cargo_cmd.extend(['-p', p])
         for e in opts.examples:

--- a/cargo_wrapper.py
+++ b/cargo_wrapper.py
@@ -69,14 +69,19 @@ def generate_depfile_for(fpath, build_start_time, logfile=None):
 
                 all_deps = []
                 for src in srcs.split(' '):
+                    src = src.strip()
                     all_deps.append(src)
                     src = P(src)
-                    if src.name == 'lib.rs':
+                    if src.name in ['lib.rs', 'main.rs']:
                         # `rustc` doesn't take `Cargo.toml` into account
                         # but we need to
                         cargo_toml = src.parent.parent / 'Cargo.toml'
+                        print(f'  Looking for {cargo_toml}: ', file=logfile, end='')
                         if cargo_toml.exists():
+                            print(f'Found', file=logfile)
                             all_deps.append(str(cargo_toml))
+                        else:
+                            print(f'Not found', file=logfile)
 
                 depfile_content += f'{output}: {' '.join(all_deps)}\n'
 

--- a/cargo_wrapper.py
+++ b/cargo_wrapper.py
@@ -26,6 +26,7 @@ PARSER.add_argument('--examples', nargs='+', default=[])
 PARSER.add_argument('--lib-suffixes', nargs='+', default=[])
 PARSER.add_argument('--exe-suffix')
 PARSER.add_argument('--depfile', type=P)
+PARSER.add_argument('--target-dir', type=P, default=None)
 PARSER.add_argument('--disable-doc', action='store_true', default=False)
 
 
@@ -95,7 +96,11 @@ if __name__ == '__main__':
     logfile = open(logfile_path, mode='w', buffering=1, encoding='utf-8')
 
     print(opts, file=logfile)
-    cargo_target_dir = opts.build_dir / 'target'
+    # Use explicitly passed target dir or default to build_dir/target
+    if opts.target_dir:
+        cargo_target_dir = opts.target_dir
+    else:
+        cargo_target_dir = opts.build_dir / 'target'
 
     env = os.environ.copy()
     if 'PKG_CONFIG_PATH' in env:

--- a/cargo_wrapper.py
+++ b/cargo_wrapper.py
@@ -83,7 +83,7 @@ def generate_depfile_for(fpath, build_start_time, logfile=None):
                         else:
                             print(f'Not found', file=logfile)
 
-                depfile_content += f'{output}: {' '.join(all_deps)}\n'
+                depfile_content += f"{output}: {' '.join(all_deps)}\n"
 
     return depfile_content
 

--- a/cargo_wrapper.py
+++ b/cargo_wrapper.py
@@ -92,7 +92,7 @@ def generate_depfile_for(fpath, build_start_time, logfile=None):
 if __name__ == '__main__':
     opts = PARSER.parse_args()
     logdir = opts.root_dir / 'meson-logs'
-    logfile_path = logdir / f'{opts.depfile.name.replace('.dep', '')}-cargo-wrapper.log'
+    logfile_path = logdir / f"{opts.depfile.name.replace('.dep', '')}-cargo-wrapper.log"
     logfile = open(logfile_path, mode='w', buffering=1, encoding='utf-8')
 
     print(opts, file=logfile)

--- a/meson.build
+++ b/meson.build
@@ -391,8 +391,9 @@ packages = []
 features = []
 # examples to build
 examples = []
-# Add the plugin library files as output
+# Add the plugin library and .pc files as output
 output = []
+install_dirs = []
 
 if get_option('gtk4').allowed()
   if glib_dep.version().version_compare('>=2.74')
@@ -433,6 +434,8 @@ if get_option('default_library') == 'static'
   }
 endif
 
+plugins_install_dir = get_option('libdir') / 'gstreamer-1.0'
+pkgconfig_install_dir = get_option('libdir') / 'pkgconfig'
 foreach plugin_name, details: plugins
   plugin_opt = get_variable(f'@plugin_name@_option', get_option(plugin_name))
   if not plugin_opt.allowed()
@@ -535,6 +538,7 @@ foreach plugin_name, details: plugins
   endif
 
   lib = details.get('library')
+  output += [lib.substring(3) + '.pc']
   # No 'lib' suffix with MSVC
   if cc.get_argument_syntax() == 'msvc'
     lib = lib.substring(3)
@@ -545,15 +549,15 @@ foreach plugin_name, details: plugins
   if default_library in ['static', 'both']
     output += [lib + '.' + ext_static]
   endif
+  install_dirs += [pkgconfig_install_dir]
+  install_dirs += [plugins_install_dir]
+
 endforeach
 
 feature_args = []
 if features.length() > 0
   feature_args += ['--features', features]
 endif
-
-plugins_install_dir = get_option('libdir') / 'gstreamer-1.0'
-pkgconfig_install_dir = get_option('libdir') / 'pkgconfig'
 
 extra_args = []
 if get_option('doc').disabled()
@@ -583,7 +587,6 @@ subdir('plugins')
 
 # This is used by GStreamer to static link Rust plugins into gst-full
 gst_plugins = []
-pc_files = []
 plugin_names = []
 foreach plugin : plugins
   plugin_name = fs.stem(plugin.full_path())
@@ -646,25 +649,10 @@ foreach plugin : plugins
     warning('Static plugin @0@ is known to fail. It will not be included in libgstreamer-full.'.format(plugin_name))
   else
     gst_plugins += dep
-    pc_files += [plugin_name + '.pc']
   endif
 endforeach
 
 subdir('docs')
-
-# We don't need to pass a command as we depends on the target above
-# but it is currently mandatory ( https://github.com/mesonbuild/meson/issues/8059 )
-# so use python as it's guaranteed to be present on any setup
-if pc_files.length() > 0
-  custom_target('gst-plugins-rs-pc-files',
-    build_by_default: true,
-    output: pc_files,
-    console: true,
-    install: true,
-    install_dir: pkgconfig_install_dir,
-    depends: rs_plugins,
-    command: [python, '-c', '""'])
-endif
 
 if get_option('webrtc').allowed()
   custom_target('gst-webrtc-signalling-server',

--- a/meson.build
+++ b/meson.build
@@ -578,31 +578,8 @@ endif
 # get cmdline for rust
 extra_env += {'RUSTC': ' '.join(rustc.cmd_array())}
 
-plugins = []
-if output.length() > 0
-  rs_plugins = custom_target('gst-plugins-rs',
-    build_by_default: true,
-    output: output,
-    console: true,
-    install: true,
-    install_dir: plugins_install_dir,
-    depends: depends,
-    depfile: 'gst-plugins-rs.dep',
-    env: extra_env,
-    command: [cargo_wrapper,
-      'build',
-      meson.current_build_dir(),
-      meson.current_source_dir(),
-      meson.global_build_root(),
-      target,
-      get_option('prefix'),
-      get_option('libdir'),
-      '--packages', packages,
-      '--depfile', '@DEPFILE@',
-      '--lib-suffixes', library_suffixes,
-    ] + feature_args + extra_args)
-  plugins = rs_plugins.to_list()
-endif
+# Build plugins in the plugins subdirectory
+subdir('plugins')
 
 # This is used by GStreamer to static link Rust plugins into gst-full
 gst_plugins = []

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,0 +1,27 @@
+plugins = []
+rs_plugins = []
+if output.length() > 0
+  rs_plugins = custom_target('gst-plugins-rs',
+    build_by_default: true,
+    output: output,
+    console: true,
+    install: true,
+    install_dir: plugins_install_dir,
+    depends: depends,
+    depfile: 'gst-plugins-rs.dep',
+    env: extra_env,
+    command: [cargo_wrapper,
+      'build',
+      meson.current_build_dir(),
+      meson.current_source_dir() / '..',
+      meson.global_build_root(),
+      target,
+      get_option('prefix'),
+      get_option('libdir'),
+      '--packages', packages,
+      '--depfile', '@DEPFILE@',
+      '--lib-suffixes', library_suffixes,
+      '--target-dir', meson.current_build_dir() / '..' / 'target',
+    ] + feature_args + extra_args)
+  plugins = rs_plugins.to_list()
+endif

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -6,7 +6,7 @@ if output.length() > 0
     output: output,
     console: true,
     install: true,
-    install_dir: plugins_install_dir,
+    install_dir: install_dirs,
     depends: depends,
     depfile: 'gst-plugins-rs.dep',
     env: extra_env,
@@ -23,5 +23,10 @@ if output.length() > 0
       '--lib-suffixes', library_suffixes,
       '--target-dir', meson.current_build_dir() / '..' / 'target',
     ] + feature_args + extra_args)
-  plugins = rs_plugins.to_list()
+  plugins = []
+  foreach plugin: rs_plugins.to_list()
+    if not plugin.full_path().endswith('.pc')
+      plugins += plugin
+    endif
+  endforeach
 endif

--- a/utils/uridecodepool/src/uridecodepool/decoderpipeline.rs
+++ b/utils/uridecodepool/src/uridecodepool/decoderpipeline.rs
@@ -577,7 +577,9 @@ impl DecoderPipeline {
                             "Could not post message {message:?}: {e:?}"
                         );
                     }
-                } else if let TargetSrcState::InUse(target) = self.target_src() {
+                }
+
+                if let TargetSrcState::InUse(target) = self.target_src() {
                     if let Err(e) = target.post_message(message.to_owned()) {
                         gst::warning!(
                             CAT,

--- a/video/skia/Cargo.toml
+++ b/video/skia/Cargo.toml
@@ -9,13 +9,14 @@ license = "MPL-2.0"
 description = "GStreamer skia plugin"
 
 [dependencies]
-skia = { package = "skia-safe", version = "0.78" }
+skia = { package = "skia-safe", version = "0.78", features = ["gpu", "gl"] }
 gst.workspace = true
 gst-base.workspace = true
 gst-video = { workspace = true, features = ["v1_20"] }
 gst-gl.workspace = true
 ges = { package = "gstreamer-editing-services", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "main", features = ["v1_24"], optional = true }
 tracing = "0.1"
+gl = "0.14.0"
 
 [lib]
 name = "gstskia"

--- a/video/skia/Cargo.toml
+++ b/video/skia/Cargo.toml
@@ -13,6 +13,7 @@ skia = { package = "skia-safe", version = "0.78" }
 gst.workspace = true
 gst-base.workspace = true
 gst-video = { workspace = true, features = ["v1_20"] }
+gst-gl.workspace = true
 ges = { package = "gstreamer-editing-services", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "main", features = ["v1_24"], optional = true }
 tracing = "0.1"
 

--- a/video/skia/src/compositor/imp.rs
+++ b/video/skia/src/compositor/imp.rs
@@ -1,4 +1,3 @@
-use glib::ControlFlow;
 // SPDX-License-Identifier: MPL-2.0
 use gst::glib::Properties;
 use gst_base::subclass::prelude::*;

--- a/video/skia/src/gl.rs
+++ b/video/skia/src/gl.rs
@@ -1,0 +1,89 @@
+use std::sync::LazyLock;
+
+const TEXTURE_2D: u32 = 0x0DE1;
+const RGBA8: u32 = 0x8058;
+
+pub fn create_backend_texture_from_gl(
+    texture_id: u32,
+    width: i32,
+    height: i32,
+    format: gst_video::VideoFormat,
+) -> Result<skia::gpu::BackendTexture, gst::LoggableError> {
+    let gl_format = match format {
+        gst_video::VideoFormat::Rgba => RGBA8,
+        _ => {
+            return Err(gst::loggable_error!(
+                CAT,
+                "Unsupported video format for GL backend texture: {:?}",
+                format
+            ));
+        }
+    };
+
+    gst::debug!(
+        CAT,
+        "Creating backend texture: id={}, {}x{}, format={:?}",
+        texture_id,
+        width,
+        height,
+        format
+    );
+
+    // Create backend texture from GL texture ID
+    Ok(unsafe {
+        skia::gpu::backend_textures::make_gl(
+            (width, height),
+            skia::gpu::Mipmapped::Yes,
+            skia::gpu::gl::TextureInfo {
+                target: TEXTURE_2D,
+                id: texture_id,
+                format: gl_format,
+                ..Default::default()
+            },
+            "",
+        )
+    })
+}
+
+pub fn create_surface_from_backend_texture(
+    context: &mut skia::gpu::DirectContext,
+    backend_texture: &skia::gpu::BackendTexture,
+    format: gst_video::VideoFormat,
+) -> Result<skia::Surface, gst::LoggableError> {
+    let color_type = match format {
+        gst_video::VideoFormat::Rgba => skia::ColorType::RGBA8888,
+        _ => {
+            return Err(gst::loggable_error!(
+                CAT,
+                "Unsupported video format for surface creation: {:?}",
+                format
+            ));
+        }
+    };
+
+    gst::debug!(
+        CAT,
+        "Creating surface from backend texture: format={:?}, color_type={:?}",
+        format,
+        color_type
+    );
+
+    skia::gpu::surfaces::wrap_backend_texture(
+        context,
+        backend_texture,
+        skia::gpu::SurfaceOrigin::TopLeft,
+        None, // Keep it simple
+        color_type,
+        None,
+        None,
+    )
+    .ok_or_else(|| gst::loggable_error!(CAT, "Failed to create output backenbd texture"))
+}
+
+static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
+    gst::DebugCategory::new(
+        "skia-gl",
+        gst::DebugColorFlags::empty(),
+        Some("Skia GL utilities"),
+    )
+});

--- a/video/skia/src/lib.rs
+++ b/video/skia/src/lib.rs
@@ -10,12 +10,15 @@
 use gst::glib;
 
 mod compositor;
+mod gl;
 mod reshape;
 mod reshape_common;
+mod reshapegl;
 
 fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
     compositor::register(plugin)?;
     reshape::register(plugin)?;
+    reshapegl::register(plugin)?;
     #[cfg(feature = "doc")]
     {
         use gst::prelude::*;

--- a/video/skia/src/lib.rs
+++ b/video/skia/src/lib.rs
@@ -11,6 +11,7 @@ use gst::glib;
 
 mod compositor;
 mod reshape;
+mod reshape_common;
 
 fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
     compositor::register(plugin)?;

--- a/video/skia/src/reshape/imp.rs
+++ b/video/skia/src/reshape/imp.rs
@@ -223,7 +223,7 @@ impl SkiaReshape {
                         if let (Some(w), Some(h)) = (width, height) {
                             state.compositor_size = Some(skia::Size::new(w as f32, h as f32));
                         } else {
-                            gst::error!(CAT, "Failed to get width/height from restriction caps");
+                            gst::info!(CAT, "Failed to get width/height from restriction caps");
                         }
                     }
                 }
@@ -338,20 +338,13 @@ impl SkiaReshape {
         let mut dst_width = img_compositor_rect.width();
         let mut dst_height = img_compositor_rect.height();
 
-        let mut original_dst_left = dst_left;
-        let mut original_dst_top = dst_top;
-        let original_dst_width = dst_width;
-        let original_dst_height = dst_height;
+        let (mut original_dst_left, mut original_dst_top) = (dst_left, dst_top);
+        let (original_dst_width, original_dst_height) = (dst_width, dst_height);
 
-        let out_x = compositor_rect.x();
-        let out_y = compositor_rect.y();
-        let mut out_width = compositor_rect.width();
-        let mut out_height = compositor_rect.height();
+        let (out_x, out_y) = (compositor_rect.x(), compositor_rect.y());
+        let (mut out_width, mut out_height) = (compositor_rect.width(), compositor_rect.height());
 
-        let crop_optimization_enabled = {
-            let settings = self.settings.lock().unwrap();
-            !settings.disable_crop_optimization
-        };
+        let crop_optimization_enabled = !self.settings.lock().unwrap().disable_crop_optimization;
 
         if crop_optimization_enabled {
             let width_factor = (in_info.width() as f32) / dst_width;
@@ -361,7 +354,6 @@ impl SkiaReshape {
                 let extra_crop_left_src = img_compositor_rect.left() * width_factor;
 
                 src_crop_left -= extra_crop_left_src;
-                let prev = dst_width;
                 dst_width += img_compositor_rect.left();
 
                 original_dst_left += img_compositor_rect.left();
@@ -381,7 +373,6 @@ impl SkiaReshape {
                 let extra_crop_right = cropped * width_factor;
 
                 src_width += extra_crop_right;
-                let prev = dst_width;
                 dst_width += cropped;
             }
 
@@ -410,7 +401,6 @@ impl SkiaReshape {
                 let extra_crop_bottom = cropped * height_factor;
 
                 src_height += extra_crop_bottom;
-                let prev = dst_height;
                 dst_height += cropped;
             }
 
@@ -428,8 +418,12 @@ impl SkiaReshape {
         let src_with_cropping_applied =
             skia::Rect::from_ltrb(src_crop_left, src_crop_top, src_width, src_height);
 
-        if dst_top < 1. { dst_top = 0.; }
-        if dst_left < 1. { dst_left = 0.; }
+        if dst_top < 1.0 {
+            dst_top = 0.0;
+        }
+        if dst_left < 1.0 {
+            dst_left = 0.0;
+        }
         let dst_rect = skia::Rect::from_xywh(dst_left, dst_top, dst_width, dst_height);
 
         let original_dst_rect = skia::Rect::from_xywh(
@@ -666,7 +660,6 @@ impl BaseTransformImpl for SkiaReshape {
             if let InputBuffer::Writable(buf) = inbuf {
                 let settings = self.settings.lock().unwrap();
                 add_custom_meta(buf, settings);
-                gst::fixme!(CAT, imp = self, "UPDATE METADATAS!!",);
                 return Ok(PrepareOutputBufferSuccess::InputBuffer);
             }
         }
@@ -725,8 +718,7 @@ impl BaseTransformImpl for SkiaReshape {
 
         // Update FrameCompositionMeta to also have the floored/ceiled values.
         let compositor_position = self.state.lock().unwrap().compositor_position;
-        let mut croppedx = 0.;
-        let mut croppedy = 0.;
+        let (mut croppedx, mut croppedy): (f64, f64) = (0.0, 0.0);
         if let Some(compositor_rect) = compositor_position {
             let rects = self.compute_src_image_and_dest_rects(None);
             #[cfg(feature = "ges")]
@@ -771,8 +763,26 @@ impl BaseTransformImpl for SkiaReshape {
                         s.set("croppedx", croppedx);
                         s.set("croppedy", croppedy);
 
-                        s.set("posx", rects.original_dst_rect.left() as f64);
-                        s.set("posy", rects.original_dst_rect.top() as f64);
+                        // When content is cropped from negative positions, we need to adjust
+                        // for the fractional pixels that were lost in the cropping
+                        let pos_x = if croppedx < 0.0 {
+                            // croppedx is negative, representing content cropped from the left
+                            // We need to add back the fractional part that was lost
+                            rects.original_dst_rect.left() as f64 - croppedx.fract()
+                        } else {
+                            rects.original_dst_rect.left() as f64
+                        };
+
+                        let pos_y = if croppedy < 0.0 {
+                            // croppedy is negative, representing content cropped from the top
+                            // We need to add back the fractional part that was lost
+                            rects.original_dst_rect.top() as f64 - croppedy.fract()
+                        } else {
+                            rects.original_dst_rect.top() as f64
+                        };
+
+                        s.set("posx", pos_x);
+                        s.set("posy", pos_y);
                         s.set("height", rects.original_dst_rect.height() as f64);
                         s.set("width", rects.original_dst_rect.width() as f64);
                     }
@@ -802,13 +812,12 @@ impl BaseTransformImpl for SkiaReshape {
         match stream_time {
             Some(stream_time) => match self.obj().sync_values(stream_time) {
                 Ok(_) => (),
-                Err(_) => {
-                    // error!("Failed to sync values: {:?}", err);
-                    // Ignoring this error for now. It seems harmless.
+                Err(err) => {
+                    gst::trace!(CAT, imp = self, "Failed to sync values: {:?}", err);
                 }
             },
             None => {
-                warn!("No stream time available");
+                gst::trace!(CAT, imp = self, "No stream time available");
             }
         }
     }
@@ -821,7 +830,7 @@ impl VideoFilterImpl for SkiaReshape {
         frame: &gst_video::VideoFrameRef<&gst::BufferRef>,
         outframe: &mut gst_video::VideoFrameRef<&mut gst::BufferRef>,
     ) -> Result<gst::FlowSuccess, gst::FlowError> {
-        let (meta, alpha) = self.frame_composition_info(outframe.buffer());
+        let (_, alpha) = self.frame_composition_info(outframe.buffer());
 
         if alpha == 0.0 {
             // Skip drawing when alpha is 0
@@ -886,7 +895,7 @@ impl VideoFilterImpl for SkiaReshape {
 
         let plane_data = match outframe.plane_data_mut(0) {
             Err(e) => {
-                error!("Failed to get plane data: {:?}", e);
+                gst::error!(CAT, imp = self, "Failed to get plane data: {:?}", e);
                 return Err(gst::FlowError::Error);
             }
             Ok(data) => data,
@@ -949,7 +958,6 @@ impl VideoFilterImpl for SkiaReshape {
             skia::RRect::new_rect_xy(rects.original_dst_rect, border_radius, border_radius);
 
         canvas.clip_rrect(rounded_dst_rect, skia::ClipOp::Difference, true);
-
         canvas.clear(skia::Color::TRANSPARENT);
 
         Ok(gst::FlowSuccess::Ok)

--- a/video/skia/src/reshape/imp.rs
+++ b/video/skia/src/reshape/imp.rs
@@ -1,16 +1,13 @@
-#[cfg(feature = "ges")]
-use ges::prelude::*;
 use gst::{
-    glib::{self, Properties},
+    glib::{self},
     subclass::prelude::*,
 };
-use gst_base::subclass::base_transform::{InputBuffer, PrepareOutputBufferSuccess};
 use gst_video::{prelude::*, subclass::prelude::*, VideoFormat};
 
 use std::sync::{LazyLock, Mutex};
 use tracing::*;
 
-const DEFAULT_BORDER_RADIUS: f64 = 0.0;
+use crate::reshape_common::{ReshapeCommon, Settings, State};
 
 static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
     gst::DebugCategory::new(
@@ -20,427 +17,23 @@ static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
     )
 });
 
-#[derive(Debug, Clone, Copy)]
-struct Settings {
-    border_radius_px: f64,
-    corner_smoothing_pct: f64,
-    padding_px: i32,
-    crop_left: i32,
-    crop_right: i32,
-    crop_top: i32,
-    crop_bottom: i32,
-    disable_crop_optimization: bool,
-}
-
-impl Default for Settings {
-    fn default() -> Self {
-        Settings {
-            border_radius_px: DEFAULT_BORDER_RADIUS,
-            corner_smoothing_pct: 0.,
-            padding_px: 0,
-            crop_left: 0,
-            crop_right: 0,
-            crop_top: 0,
-            crop_bottom: 0,
-            disable_crop_optimization: false,
-        }
-    }
-}
-
 #[derive(Default, Debug)]
-struct State {
-    in_info: Option<gst_video::VideoInfo>,
-    out_info: Option<gst_video::VideoInfo>,
-
-    // Wanted position of the image taking into account padding
-    compositor_position: Option<skia::Rect>,
-
-    // Output size of the **compositor itself**
-    compositor_size: Option<skia::Size>,
-}
-
-#[derive(Default, Properties, Debug)]
-#[properties(wrapper_type = super::SkiaReshape)]
 pub struct SkiaReshape {
-    #[property(
-        name = "border-radius-px",
-        type = f64,
-        get,
-        set,
-        nick = "Border radius in pixels",
-        blurb = "Draw rounded corners with given border radius",
-        default_value = DEFAULT_BORDER_RADIUS,
-        controllable,
-        mutable_playing,
-        member = border_radius_px
-    )]
-    #[property(
-        name = "corner-smoothing-pct",
-        type = f64,
-        get,
-        set,
-        nick = "Corner smoothing in percentage",
-        blurb = "Draw rounded corners with corner smoothing",
-        default_value = 0.0,
-        controllable,
-        mutable_playing,
-        member = corner_smoothing_pct
-    )]
-    #[property(
-        name = "padding-px",
-        type = i32,
-        get,
-        set,
-        nick = "Padding in pixels",
-        blurb = "Extending the box for drawing borders/shadows",
-        default_value = 0,
-        controllable,
-        mutable_playing,
-        member = padding_px
-    )]
-    #[property(
-        name = "left",
-        type = i32,
-        get,
-        set,
-        nick = "Crop left in pixels",
-        blurb = "Crop left in pixels",
-        default_value = 0,
-        controllable,
-        mutable_playing,
-        member = crop_left
-    )]
-    #[property(
-        name = "right",
-        type = i32,
-        get,
-        set,
-        nick = "Crop right in pixels",
-        blurb = "Crop right in pixels",
-        default_value = 0,
-        controllable,
-        mutable_playing,
-        member = crop_right
-    )]
-    #[property(
-        name = "top",
-        type = i32,
-        get,
-        set,
-        nick = "Crop top in pixels",
-        blurb = "Crop top in pixels",
-        default_value = 0,
-        controllable,
-        mutable_playing,
-        member = crop_top
-    )]
-    #[property(
-        name = "bottom",
-        type = i32,
-        get,
-        set,
-        nick = "Crop bottom in pixels",
-        blurb = "Crop bottom in pixels",
-        default_value = 0,
-        controllable,
-        mutable_playing,
-        member = crop_bottom
-    )]
-    #[property(
-        name = "disable-crop-optimization",
-        type = bool,
-        get,
-        set,
-        nick = "Disable crop optimization",
-        blurb = "Disable the 'big zoom' crop optimization that reduces output buffer size",
-        default_value = false,
-        mutable_playing,
-        member = disable_crop_optimization
-    )]
     settings: Mutex<Settings>,
     state: Mutex<State>,
 }
 
-#[derive(Debug, Copy, Clone)]
-struct TranslationRects {
-    // The rectangle that is used to crop the source image
-    src_with_cropping_applied: skia::Rect,
-
-    // The rectangle that is used to draw the image
-    dst_rect: skia::Rect,
-
-    // The rectangle that correspond to where the optimized cropped image correspond
-    // after cropping is applied
-    original_dst_rect: skia::Rect,
-
-    // The final position in the compositor, after taking account all cropping
-    final_position: skia::Rect,
-}
-
-impl SkiaReshape {
-    fn frame_composition_info(&self, _buf: &gst::BufferRef) -> (Option<skia::Rect>, f64) {
-        #[cfg(feature = "ges")]
-        {
-            if let Some(meta) = _buf.meta::<ges::prelude::FrameCompositionMeta>() {
-                let padding = self.settings.lock().unwrap().padding_px as f32;
-                (
-                    Some(skia::Rect::from_xywh(
-                        meta.pos_x() as f32,
-                        meta.pos_y() as f32,
-                        meta.width() as f32 + padding * 2.,
-                        meta.height() as f32 + padding * 2.,
-                    )),
-                    meta.alpha(),
-                )
-            } else {
-                (None, 1.0)
-            }
-        }
-        #[cfg(not(feature = "ges"))]
-        (None, 1.0)
+impl ReshapeCommon for SkiaReshape {
+    fn settings(&self) -> std::sync::MutexGuard<'_, Settings> {
+        self.settings.lock().unwrap()
     }
 
-    #[cfg(not(feature = "ges"))]
-    fn setup_compositor_size(&self) {}
-
-    #[cfg(feature = "ges")]
-    fn setup_compositor_size(&self) {
-        let mut parent = Some(self.obj().clone().upcast::<gst::Object>());
-        while let Some(p) = parent {
-            if let Some(track) = p.downcast_ref::<ges::VideoTrack>() {
-                let mut state = self.state.lock().unwrap();
-                state.compositor_size = None;
-                if let Some(caps) = track.restriction_caps() {
-                    for structure in caps.iter() {
-                        let (mut width, mut height) = (None, None);
-                        if let Ok(w) = structure.get::<i32>("width") {
-                            width = Some(w);
-                        }
-                        if let Ok(h) = structure.get::<i32>("height") {
-                            height = Some(h);
-                        }
-
-                        if let (Some(w), Some(h)) = (width, height) {
-                            state.compositor_size = Some(skia::Size::new(w as f32, h as f32));
-                        } else {
-                            gst::info!(CAT, "Failed to get width/height from restriction caps");
-                        }
-                    }
-                }
-
-                gst::info!(
-                    CAT,
-                    imp = self,
-                    "Compositor size: {:?}",
-                    state.compositor_size
-                );
-
-                break;
-            }
-
-            parent = p.parent()
-        }
-    }
-
-    fn compute_output_size(&self, caps: &gst::Caps) -> (Option<i32>, Option<i32>) {
-        if let Ok(rects) = self.compute_src_image_and_dest_rects(Some(caps)) {
-            (
-                Some(rects.final_position.width().ceil() as i32),
-                Some(rects.final_position.height().ceil() as i32),
-            )
-        } else if let Some(rect) = self.state.lock().unwrap().compositor_position {
-            (
-                Some(rect.width().ceil() as i32),
-                Some(rect.height().ceil() as i32),
-            )
-        } else {
-            (None, None)
-        }
-    }
-
-    fn compute_src_image_and_dest_rects(
-        &self,
-        incaps: Option<&gst::Caps>,
-    ) -> Result<TranslationRects, gst::FlowError> {
-        let state = self.state.lock().unwrap();
-        let in_info = if let Some(in_info) = state.in_info.as_ref() {
-            in_info.clone()
-        } else if let Some(incaps) = incaps {
-            if !incaps.is_fixed() {
-                return Err(gst::FlowError::NotNegotiated);
-            }
-
-            if let Ok(info) = gst_video::VideoInfo::from_caps(incaps) {
-                info
-            } else {
-                return Err(gst::FlowError::NotNegotiated);
-            }
-        } else {
-            gst::element_imp_error!(self, gst::CoreError::Negotiation, ["Have no state yet"]);
-            return Err(gst::FlowError::NotNegotiated);
-        };
-
-        let compositor_size = state.compositor_size.unwrap_or(skia::Size::new(
-            in_info.width() as f32,
-            in_info.height() as f32,
-        ));
-
-        let out_frame_size = if let Some(out_info) = state.out_info.as_ref() {
-            skia::Size::new(out_info.width() as f32, out_info.height() as f32)
-        } else {
-            compositor_size
-        };
-
-        let (padding_px, mut src_crop_left, crop_right, mut src_crop_top, crop_bottom) = {
-            let settings = self.settings.lock().unwrap();
-            (
-                settings.padding_px as f32,
-                settings.crop_left as f32,
-                settings.crop_right as f32,
-                settings.crop_top as f32,
-                settings.crop_bottom as f32,
-            )
-        };
-
-        // We have extended the video frame to get rid of floats in transform_caps,
-        // we will draw the video frame anti-aliassed on the x_offset and y_offset.
-        // Doing it this way means the compositor doesn't need to do any
-        // scaling/anti-aliassing, we already do it here instead.
-        let (mut dst_left, mut dst_top, compositor_rect, img_compositor_rect) =
-            if let Some(ref position_in_compositor) = state.compositor_position {
-                let x = position_in_compositor.left();
-                let y = position_in_compositor.top();
-
-                (
-                    x - x.floor(),
-                    y - y.floor(),
-                    *position_in_compositor,
-                    skia::Rect::from_xywh(
-                        position_in_compositor.x() + padding_px,
-                        position_in_compositor.y() + padding_px,
-                        position_in_compositor.width() - 2. * padding_px,
-                        position_in_compositor.height() - 2. * padding_px,
-                    ),
-                )
-            } else {
-                (
-                    0.0,
-                    0.0,
-                    skia::Rect::from_xywh(0., 0., out_frame_size.width, out_frame_size.height),
-                    skia::Rect::from_xywh(0., 0., out_frame_size.width, out_frame_size.height),
-                )
-            };
-        drop(state);
-
-        let mut src_width = in_info.width() as f32 - crop_right;
-        let mut src_height = in_info.height() as f32 - crop_bottom;
-
-        let mut dst_width = img_compositor_rect.width();
-        let mut dst_height = img_compositor_rect.height();
-
-        let (mut original_dst_left, mut original_dst_top) = (dst_left, dst_top);
-        let (original_dst_width, original_dst_height) = (dst_width, dst_height);
-
-        let (out_x, out_y) = (compositor_rect.x(), compositor_rect.y());
-        let (mut out_width, mut out_height) = (compositor_rect.width(), compositor_rect.height());
-
-        let crop_optimization_enabled = !self.settings.lock().unwrap().disable_crop_optimization;
-
-        if crop_optimization_enabled {
-            let width_factor = (in_info.width() as f32) / dst_width;
-            let height_factor = in_info.height() as f32 / dst_height;
-
-            if img_compositor_rect.left() < 0. {
-                let extra_crop_left_src = img_compositor_rect.left() * width_factor;
-
-                src_crop_left -= extra_crop_left_src;
-                dst_width += img_compositor_rect.left();
-
-                original_dst_left += img_compositor_rect.left();
-                out_width += compositor_rect.left();
-            } else if compositor_rect.left() < 0. {
-                dst_left += img_compositor_rect.left();
-                original_dst_left += img_compositor_rect.left();
-
-                out_width += compositor_rect.left();
-            } else {
-                dst_left += padding_px;
-                original_dst_left += padding_px;
-            }
-
-            if img_compositor_rect.right() > compositor_size.width {
-                let cropped = compositor_size.width - img_compositor_rect.right();
-                let extra_crop_right = cropped * width_factor;
-
-                src_width += extra_crop_right;
-                dst_width += cropped;
-            }
-
-            if compositor_rect.right() > compositor_size.width {
-                out_width += compositor_size.width - compositor_rect.right();
-            }
-
-            if img_compositor_rect.top() < 0. {
-                let extra_crop_top = img_compositor_rect.top() * height_factor;
-
-                src_crop_top -= extra_crop_top;
-                dst_height += img_compositor_rect.top();
-                original_dst_top += img_compositor_rect.top();
-                out_height += compositor_rect.top();
-            } else if compositor_rect.top() < 0. {
-                dst_top += compositor_rect.top() + padding_px;
-                original_dst_top += compositor_rect.top() + padding_px;
-                out_height += compositor_rect.top();
-            } else {
-                dst_top += padding_px;
-                original_dst_top += padding_px;
-            }
-
-            if img_compositor_rect.bottom() > compositor_size.height {
-                let cropped = compositor_size.height - img_compositor_rect.bottom();
-                let extra_crop_bottom = cropped * height_factor;
-
-                src_height += extra_crop_bottom;
-                dst_height += cropped;
-            }
-
-            if compositor_rect.bottom() > compositor_size.height {
-                out_height += compositor_size.height - compositor_rect.bottom();
-            }
-        } else {
-            dst_left += padding_px;
-            dst_top += padding_px;
-
-            original_dst_left += padding_px;
-            original_dst_top += padding_px;
-        }
-
-        let src_with_cropping_applied =
-            skia::Rect::from_ltrb(src_crop_left, src_crop_top, src_width, src_height);
-
-        if dst_top < 1.0 {
-            dst_top = 0.0;
-        }
-        if dst_left < 1.0 {
-            dst_left = 0.0;
-        }
-        let dst_rect = skia::Rect::from_xywh(dst_left, dst_top, dst_width, dst_height);
-
-        let original_dst_rect = skia::Rect::from_xywh(
-            original_dst_left,
-            original_dst_top,
-            original_dst_width,
-            original_dst_height,
-        );
-
-        Ok(TranslationRects {
-            src_with_cropping_applied,
-            dst_rect,
-            original_dst_rect,
-            final_position: skia::Rect::from_xywh(out_x, out_y, out_width, out_height),
-        })
+    fn state(&self) -> std::sync::MutexGuard<'_, State> {
+        self.state.lock().unwrap()
     }
 }
+
+impl SkiaReshape {}
 
 #[glib::object_subclass]
 impl ObjectSubclass for SkiaReshape {
@@ -449,8 +42,21 @@ impl ObjectSubclass for SkiaReshape {
     type ParentType = gst_video::VideoFilter;
 }
 
-#[glib::derived_properties]
-impl ObjectImpl for SkiaReshape {}
+impl ObjectImpl for SkiaReshape {
+    fn properties() -> &'static [glib::ParamSpec] {
+        static PROPERTIES: LazyLock<Vec<glib::ParamSpec>> =
+            LazyLock::new(|| crate::reshape_common::reshape_properties());
+        PROPERTIES.as_ref()
+    }
+
+    fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        self.reshape_property(_id, pspec)
+    }
+
+    fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+        self.reshape_set_property(_id, value, pspec)
+    }
+}
 
 impl GstObjectImpl for SkiaReshape {}
 
@@ -506,39 +112,11 @@ impl BaseTransformImpl for SkiaReshape {
     const TRANSFORM_IP_ON_PASSTHROUGH: bool = false;
 
     fn start(&self) -> Result<(), gst::ErrorMessage> {
-        gst::debug!(CAT, imp = self, "Starting");
-
-        self.setup_compositor_size();
-
-        self.parent_start()
+        self.reshape_start()
     }
 
     fn set_caps(&self, incaps: &gst::Caps, outcaps: &gst::Caps) -> Result<(), gst::LoggableError> {
-        let (in_info, out_info) = match (
-            gst_video::VideoInfo::from_caps(incaps),
-            gst_video::VideoInfo::from_caps(outcaps),
-        ) {
-            (Ok(in_info), Ok(out_info)) => (in_info, out_info),
-            _ => return Err(gst::loggable_error!(CAT, "Failed to parse output caps")),
-        };
-
-        gst::debug!(
-            CAT,
-            imp = self,
-            "Scaling from {}x{} to {}x{}",
-            in_info.width(),
-            in_info.height(),
-            out_info.width(),
-            out_info.height(),
-        );
-
-        {
-            let mut state = self.state.lock().unwrap();
-            state.in_info = Some(in_info);
-            state.out_info = Some(out_info);
-        }
-
-        self.parent_set_caps(incaps, outcaps)
+        self.reshape_set_caps(incaps, outcaps)
     }
 
     fn transform_caps(
@@ -547,70 +125,7 @@ impl BaseTransformImpl for SkiaReshape {
         caps: &gst::Caps,
         filter: Option<&gst::Caps>,
     ) -> Option<gst::Caps> {
-        match direction {
-            gst::PadDirection::Src => {
-                let mut caps = caps.copy();
-                caps.make_mut().map_in_place(move |_features, structure| {
-                    structure.remove_fields(["width", "height"]);
-
-                    std::ops::ControlFlow::Continue(())
-                });
-                self.parent_transform_caps(direction, &caps, filter)
-            }
-            gst::PadDirection::Sink => {
-                let (width, height) = self.compute_output_size(caps);
-
-                if (width, height) == (None, None) {
-                    let mut caps = caps.copy();
-                    let settings = self.settings.lock().unwrap();
-                    caps.get_mut()
-                        .unwrap()
-                        .map_in_place(move |_features, structure| {
-                            if let Ok(width) = structure.get::<i32>("width") {
-                                structure.set(
-                                    "width",
-                                    width - settings.crop_left - settings.crop_right
-                                        + 2 * settings.padding_px,
-                                );
-                            }
-
-                            if let Ok(height) = structure.get::<i32>("height") {
-                                structure.set(
-                                    "height",
-                                    height - settings.crop_top - settings.crop_top
-                                        + 2 * settings.padding_px,
-                                );
-                            }
-
-                            std::ops::ControlFlow::Continue(())
-                        });
-                    gst::debug!(
-                        CAT,
-                        imp = self,
-                        "Not in GES.... transformed caps: {caps:#?}"
-                    );
-                    return self.parent_transform_caps(direction, &caps, filter);
-                }
-
-                let mut caps = caps.copy();
-                caps.get_mut()
-                    .unwrap()
-                    .map_in_place(move |_features, structure| {
-                        if let Some(ref width) = width {
-                            structure.set("width", width);
-                        }
-
-                        if let Some(ref height) = height {
-                            structure.set("height", height);
-                        }
-
-                        std::ops::ControlFlow::Continue(())
-                    });
-
-                self.parent_transform_caps(direction, &caps, filter)
-            }
-            _ => unreachable!(),
-        }
+        self.reshape_transform_caps(direction, caps, filter)
     }
 
     fn submit_input_buffer(
@@ -618,208 +133,19 @@ impl BaseTransformImpl for SkiaReshape {
         is_discont: bool,
         inbuf: gst::Buffer,
     ) -> Result<gst::FlowSuccess, gst::FlowError> {
-        let (compositor_position, _) = self.frame_composition_info(&inbuf);
-
-        {
-            let mut state = self.state.lock().unwrap();
-            if state.compositor_position != compositor_position {
-                state.compositor_position = compositor_position;
-                gst::debug!(
-                    CAT,
-                    imp = self,
-                    "Compositor position changed to: {:?}",
-                    state.compositor_position,
-                );
-                drop(state);
-
-                self.obj().reconfigure_src();
-            }
-        }
-
-        self.parent_submit_input_buffer(is_discont, inbuf)
+        self.reshape_submit_input_buffer(is_discont, inbuf)
     }
 
-    fn prepare_output_buffer(
+    fn copy_metadata(
         &self,
-        inbuf: InputBuffer,
-    ) -> Result<PrepareOutputBufferSuccess, gst::FlowError> {
-        if self.obj().is_passthrough() {
-            return Ok(PrepareOutputBufferSuccess::InputBuffer);
-        }
-
-        let (rect, in_size) = match inbuf {
-            InputBuffer::Writable(ref buf) => (self.frame_composition_info(buf).0, buf.size()),
-            InputBuffer::Readable(buf) => (self.frame_composition_info(buf).0, 0),
-        };
-
-        let state = self.state.lock().unwrap();
-        let out_info = state.out_info.as_ref().unwrap().clone();
-        assert!(rect == state.compositor_position);
-        drop(state);
-        if out_info.size() == in_size {
-            if let InputBuffer::Writable(buf) = inbuf {
-                let settings = self.settings.lock().unwrap();
-                add_custom_meta(buf, settings);
-                return Ok(PrepareOutputBufferSuccess::InputBuffer);
-            }
-        }
-
-        let mut outbuf = if let (Some(allocator), params) = self.obj().allocator() {
-            let mem = allocator
-                .alloc(out_info.size(), Some(&params))
-                .map_err(|_| {
-                    gst::error!(CAT, "Failed to allocate memory of size {}", out_info.size());
-                    gst::FlowError::Error
-                })?;
-
-            let mut buf = gst::Buffer::new();
-            let mut_buf = buf.make_mut();
-            mut_buf.append_memory(mem);
-
-            unsafe {
-                gst::ffi::gst_mini_object_lock(
-                    buf.as_mut_ptr() as *mut _,
-                    gst::ffi::GST_LOCK_FLAG_EXCLUSIVE,
-                );
-            }
-
-            buf
-        } else {
-            gst::Buffer::with_size(out_info.size()).map_err(|_| {
-                gst::error!(CAT, "Failed to allocate buffer of size {}", out_info.size());
-                gst::FlowError::Error
-            })?
-        };
-
-        let mut_outbuf = outbuf.make_mut();
-        let inbuf = match inbuf {
-            InputBuffer::Writable(ref buf) => buf,
-            InputBuffer::Readable(buf) => buf,
-        };
-
-        inbuf
-            .copy_into(mut_outbuf, gst::BufferCopyFlags::all(), 0..0)
-            .map_err(|_| {
-                gst::error!(CAT, "Failed to copy buffer of size {}", out_info.size());
-                gst::FlowError::Error
-            })?;
-        let settings = self.settings.lock().unwrap();
-        let crop_optimization_enabled = !settings.disable_crop_optimization;
-        add_custom_meta(mut_outbuf, settings);
-        add_original_frame_meta(mut_outbuf, inbuf);
-
-        self.copy_metadata(inbuf, mut_outbuf).map_err(|_| {
-            gst::error!(
-                CAT,
-                "Failed to copy metadata from input buffer to output buffer"
-            );
-            gst::FlowError::Error
-        })?;
-
-        // Update FrameCompositionMeta to also have the floored/ceiled values.
-        let compositor_position = self.state.lock().unwrap().compositor_position;
-        let (mut croppedx, mut croppedy): (f64, f64) = (0.0, 0.0);
-        if let Some(compositor_rect) = compositor_position {
-            let rects = self.compute_src_image_and_dest_rects(None);
-            #[cfg(feature = "ges")]
-            if let Some(mut meta) = mut_outbuf.meta_mut::<ges::prelude::FrameCompositionMeta>() {
-                // We need to floor the x and y values, and ceil the width and height
-                let mut x = compositor_rect.x() as f64;
-                let mut y = compositor_rect.y() as f64;
-                let mut width = compositor_rect.width() as f64;
-                let mut height = compositor_rect.height() as f64;
-
-                if crop_optimization_enabled {
-                    gst::log!(CAT, imp = self, "Big zoom optimization enabled");
-                    if let Ok(rects) = rects {
-                        width = rects.final_position.width() as f64;
-                        height = rects.final_position.height() as f64;
-                        if compositor_rect.left() < 0. {
-                            x = 0.;
-                            croppedx = compositor_rect.left() as f64;
-                        }
-
-                        if compositor_rect.top() < 0. {
-                            y = 0.;
-                            croppedy = compositor_rect.top() as f64;
-                        }
-                    }
-                }
-
-                meta.set_pos_x(x.floor());
-                meta.set_pos_y(y.floor());
-                meta.set_width(width.ceil());
-                meta.set_height(height.ceil());
-            }
-
-            if crop_optimization_enabled {
-                if let Ok(mut meta) = gst::meta::CustomMeta::from_mut_buffer(
-                    mut_outbuf,
-                    "OriginalFrameCompositionMeta",
-                ) {
-                    if let Ok(rects) = rects {
-                        let s = meta.mut_structure();
-
-                        s.set("croppedx", croppedx);
-                        s.set("croppedy", croppedy);
-
-                        // When content is cropped from negative positions, we need to adjust
-                        // for the fractional pixels that were lost in the cropping
-                        let pos_x = if croppedx < 0.0 {
-                            // croppedx is negative, representing content cropped from the left
-                            // We need to add back the fractional part that was lost
-                            rects.original_dst_rect.left() as f64 - croppedx.fract()
-                        } else {
-                            rects.original_dst_rect.left() as f64
-                        };
-
-                        let pos_y = if croppedy < 0.0 {
-                            // croppedy is negative, representing content cropped from the top
-                            // We need to add back the fractional part that was lost
-                            rects.original_dst_rect.top() as f64 - croppedy.fract()
-                        } else {
-                            rects.original_dst_rect.top() as f64
-                        };
-
-                        s.set("posx", pos_x);
-                        s.set("posy", pos_y);
-                        s.set("height", rects.original_dst_rect.height() as f64);
-                        s.set("width", rects.original_dst_rect.width() as f64);
-                    }
-                } else {
-                    gst::debug!(
-                        CAT,
-                        imp = self,
-                        "Failed to get OriginalFrameCompositionMeta"
-                    );
-                }
-            }
-
-            #[cfg(not(feature = "ges"))]
-            {
-                let _ = compositor_rect;
-            }
-        }
-
-        Ok(PrepareOutputBufferSuccess::Buffer(mut_outbuf.to_owned()))
+        inbuf: &gst::BufferRef,
+        outbuf: &mut gst::BufferRef,
+    ) -> Result<(), gst::LoggableError> {
+        self.reshape_copy_metadata(inbuf, outbuf)
     }
 
     fn before_transform(&self, inbuf: &gst::BufferRef) {
-        let timestamp = inbuf.pts().expect("Buffer without PTS");
-        let segment = self.obj().segment().downcast::<gst::ClockTime>().ok();
-        let stream_time = segment.as_ref().and_then(|s| s.to_stream_time(timestamp));
-
-        match stream_time {
-            Some(stream_time) => match self.obj().sync_values(stream_time) {
-                Ok(_) => (),
-                Err(err) => {
-                    gst::trace!(CAT, imp = self, "Failed to sync values: {:?}", err);
-                }
-            },
-            None => {
-                gst::trace!(CAT, imp = self, "No stream time available");
-            }
-        }
+        self.reshape_before_transform(inbuf)
     }
 }
 
@@ -916,91 +242,6 @@ impl VideoFilterImpl for SkiaReshape {
             skia::surface::surfaces::wrap_pixels(&out_img_info, plane_data, row_bytes, None)
                 .ok_or(gst::FlowError::Error)?;
 
-        let canvas = out_surface.canvas();
-
-        let crop_optimization_enabled = !self.settings.lock().unwrap().disable_crop_optimization;
-        gst::trace!(
-            CAT,
-            imp = self,
-            "Drawing frame with crop optimization: {}",
-            if crop_optimization_enabled {
-                "enabled"
-            } else {
-                "disabled"
-            }
-        );
-        let rects = self.compute_src_image_and_dest_rects(None)?;
-
-        // Clear the whole canvas, else we get artifacts from the previous frame
-        canvas.clear(skia::Color::TRANSPARENT);
-
-        // Draw the video frame at the correct position, with anti-aliasing.
-        let mut paint = skia::Paint::default();
-        paint.set_anti_alias(true);
-        paint.set_blend_mode(skia::BlendMode::Src);
-
-        let src_rect = Some((
-            &rects.src_with_cropping_applied,
-            skia::canvas::SrcRectConstraint::Strict,
-        ));
-
-        canvas.draw_image_rect_with_sampling_options(
-            &image,
-            src_rect,
-            rects.dst_rect,
-            skia::SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::Linear),
-            &paint,
-        );
-
-        // Clip out the rounded corners
-        let border_radius = self.settings.lock().unwrap().border_radius_px as f32;
-        let rounded_dst_rect =
-            skia::RRect::new_rect_xy(rects.original_dst_rect, border_radius, border_radius);
-
-        canvas.clip_rrect(rounded_dst_rect, skia::ClipOp::Difference, true);
-        canvas.clear(skia::Color::TRANSPARENT);
-
-        Ok(gst::FlowSuccess::Ok)
-    }
-}
-
-fn add_custom_meta(outbuf: &mut gst::BufferRef, settings: std::sync::MutexGuard<'_, Settings>) {
-    let mut meta = if let Ok(meta) = gst::meta::CustomMeta::add(outbuf, "RoundedCornersFrameMeta") {
-        meta
-    } else {
-        gst::info!(CAT, "RoundedCornersFrameMeta not registered");
-        return;
-    };
-    let s = meta.mut_structure();
-    s.set("border-radius-px", settings.border_radius_px);
-    s.set("corner-smoothing-pct", settings.corner_smoothing_pct);
-}
-
-fn add_original_frame_meta(outbuf: &mut gst::BufferRef, inbuf: &gst::BufferRef) {
-    #[cfg(feature = "ges")]
-    {
-        if let Some(meta) = inbuf.meta::<ges::prelude::FrameCompositionMeta>() {
-            let mut new_meta = if let Ok(new_meta) =
-                gst::meta::CustomMeta::add(outbuf, "OriginalFrameCompositionMeta")
-            {
-                new_meta
-            } else {
-                gst::info!(CAT, "OriginalFrameCompositionMeta not registered");
-                return;
-            };
-            let s = new_meta.mut_structure();
-            s.set("alpha", meta.alpha());
-            s.set("posx", meta.pos_x());
-            s.set("posy", meta.pos_y());
-            s.set("height", meta.height());
-            s.set("width", meta.width());
-            s.set("zorder", meta.zorder());
-            s.set("operator", meta.operator());
-            gst::trace!(CAT, "OriginalFrameCompositionMeta: {:#?}", s);
-        }
-    }
-    #[cfg(not(feature = "ges"))]
-    {
-        let _ = (outbuf, inbuf);
+        self.reshape(out_surface.canvas(), &image)
     }
 }

--- a/video/skia/src/reshape/imp.rs
+++ b/video/skia/src/reshape/imp.rs
@@ -76,25 +76,22 @@ impl ElementImpl for SkiaReshape {
 
     fn pad_templates() -> &'static [gst::PadTemplate] {
         static PAD_TEMPLATES: LazyLock<Vec<gst::PadTemplate>> = LazyLock::new(|| {
-            let sink_caps = gst_video::VideoCapsBuilder::new()
+            let caps = gst_video::VideoCapsBuilder::new()
                 .format(VideoFormat::Rgba)
                 .build();
             let sink_pad_template = gst::PadTemplate::new(
                 "sink",
                 gst::PadDirection::Sink,
                 gst::PadPresence::Always,
-                &sink_caps,
+                &caps,
             )
             .unwrap();
 
-            let src_caps = gst_video::VideoCapsBuilder::new()
-                .format(VideoFormat::Rgba)
-                .build();
             let src_pad_template = gst::PadTemplate::new(
                 "src",
                 gst::PadDirection::Src,
                 gst::PadPresence::Always,
-                &src_caps,
+                &caps,
             )
             .unwrap();
 

--- a/video/skia/src/reshape_common.rs
+++ b/video/skia/src/reshape_common.rs
@@ -1,0 +1,828 @@
+#[cfg(feature = "ges")]
+use ges::prelude::*;
+use gst::{glib, subclass::prelude::*};
+use gst_video::{prelude::*, subclass::prelude::*};
+
+use std::sync::LazyLock;
+
+pub const DEFAULT_BORDER_RADIUS: f64 = 0.0;
+
+static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
+    gst::DebugCategory::new(
+        "skiareshape-common",
+        gst::DebugColorFlags::empty(),
+        Some("Common Reshape video with skia functionality"),
+    )
+});
+
+#[derive(Debug, Clone, Copy)]
+pub struct Settings {
+    pub border_radius_px: f64,
+    pub corner_smoothing_pct: f64,
+    pub padding_px: i32,
+    pub crop_left: i32,
+    pub crop_right: i32,
+    pub crop_top: i32,
+    pub crop_bottom: i32,
+    pub disable_crop_optimization: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Settings {
+            border_radius_px: DEFAULT_BORDER_RADIUS,
+            corner_smoothing_pct: 0.,
+            padding_px: 0,
+            crop_left: 0,
+            crop_right: 0,
+            crop_top: 0,
+            crop_bottom: 0,
+            disable_crop_optimization: true,
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct State {
+    pub in_info: Option<gst_video::VideoInfo>,
+    pub out_info: Option<gst_video::VideoInfo>,
+
+    // Wanted position of the image taking into account padding
+    pub compositor_position: Option<skia::Rect>,
+
+    // Output size of the **compositor itself**
+    pub compositor_size: Option<skia::Size>,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct TranslationRects {
+    // The rectangle that is used to crop the source image
+    pub src_with_cropping_applied: skia::Rect,
+
+    // The rectangle that is used to draw the image
+    pub dst_rect: skia::Rect,
+
+    // The rectangle that correspond to where the optimized cropped image correspond
+    // after cropping is applied
+    pub original_dst_rect: skia::Rect,
+
+    // The final position in the compositor, after taking account all cropping
+    pub final_position: skia::Rect,
+}
+
+pub(crate) fn reshape_properties() -> Vec<glib::ParamSpec> {
+    vec![
+        glib::ParamSpecDouble::builder("border-radius-px")
+            .nick("Border radius in pixels")
+            .blurb("Draw rounded corners with given border radius")
+            .minimum(0.0)
+            .default_value(DEFAULT_BORDER_RADIUS)
+            .mutable_playing()
+            .controllable()
+            .build(),
+        glib::ParamSpecDouble::builder("corner-smoothing-pct")
+            .nick("Corner smoothing in percentage")
+            .blurb("Draw rounded corners with corner smoothing")
+            .default_value(0.0)
+            .mutable_playing()
+            .controllable()
+            .build(),
+        glib::ParamSpecInt::builder("padding-px")
+            .nick("Padding in pixels")
+            .blurb("Extending the box for drawing borders/shadows")
+            .default_value(0)
+            .mutable_playing()
+            .build(),
+        glib::ParamSpecInt::builder("left")
+            .nick("Crop left in pixels")
+            .blurb("Crop left in pixels")
+            .default_value(0)
+            .mutable_playing()
+            .build(),
+        glib::ParamSpecInt::builder("right")
+            .nick("Crop right in pixels")
+            .blurb("Crop right in pixels")
+            .default_value(0)
+            .mutable_playing()
+            .controllable()
+            .build(),
+        glib::ParamSpecInt::builder("top")
+            .nick("Crop top in pixels")
+            .blurb("Crop top in pixels")
+            .default_value(0)
+            .mutable_playing()
+            .controllable()
+            .build(),
+        glib::ParamSpecInt::builder("bottom")
+            .nick("Crop bottom in pixels")
+            .blurb("Crop bottom in pixels")
+            .default_value(0)
+            .mutable_playing()
+            .controllable()
+            .build(),
+        glib::ParamSpecBoolean::builder("disable-crop-optimization")
+            .nick("Disable crop optimization")
+            .blurb("Disable the 'big zoom' crop optimization that reduces output buffer size")
+            .default_value(true)
+            .mutable_playing()
+            .controllable()
+            .build(),
+    ]
+}
+
+/// Common functionality for reshape implementations
+pub trait ReshapeCommon: BaseTransformImpl + ObjectImpl {
+    fn settings(&self) -> std::sync::MutexGuard<'_, Settings>;
+    fn state(&self) -> std::sync::MutexGuard<'_, State>;
+
+    fn reshape_set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+        let mut settings = self.settings();
+        match pspec.name() {
+            "border-radius-px" => {
+                settings.border_radius_px = value.get().expect("type checked upstream");
+            }
+            "corner-smoothing-pct" => {
+                settings.corner_smoothing_pct = value.get().expect("type checked upstream");
+            }
+            "padding-px" => {
+                settings.padding_px = value.get().expect("type checked upstream");
+            }
+            "left" => {
+                settings.crop_left = value.get().expect("type checked upstream");
+            }
+            "right" => {
+                settings.crop_right = value.get().expect("type checked upstream");
+            }
+            "top" => {
+                settings.crop_top = value.get().expect("type checked upstream");
+            }
+            "bottom" => {
+                settings.crop_bottom = value.get().expect("type checked upstream");
+            }
+            "disable-crop-optimization" => {
+                settings.disable_crop_optimization = value.get().expect("type checked upstream");
+            }
+            _ => unimplemented!(),
+        }
+    }
+
+    fn reshape_property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        let settings = self.settings();
+        match pspec.name() {
+            "border-radius-px" => settings.border_radius_px.to_value(),
+            "corner-smoothing-pct" => settings.corner_smoothing_pct.to_value(),
+            "padding-px" => settings.padding_px.to_value(),
+            "left" => settings.crop_left.to_value(),
+            "right" => settings.crop_right.to_value(),
+            "top" => settings.crop_top.to_value(),
+            "bottom" => settings.crop_bottom.to_value(),
+            "disable-crop-optimization" => settings.disable_crop_optimization.to_value(),
+            _ => unimplemented!(),
+        }
+    }
+
+    fn reshape(
+        &self,
+        canvas: &skia::Canvas,
+        image: &skia::Image,
+    ) -> Result<gst::FlowSuccess, gst::FlowError> {
+        let crop_optimization_enabled = !self.settings().disable_crop_optimization;
+        gst::trace!(
+            CAT,
+            imp = self,
+            "Drawing frame with crop optimization: {}",
+            if crop_optimization_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            }
+        );
+        let rects = self.compute_src_image_and_dest_rects(None)?;
+
+        // Clear the whole canvas, else we get artifacts from the previous frame
+        canvas.clear(skia::Color::TRANSPARENT);
+
+        // Draw the video frame at the correct position, with anti-aliasing.
+        let mut paint = skia::Paint::default();
+        paint.set_anti_alias(true);
+
+        let src_rect = Some((
+            &rects.src_with_cropping_applied,
+            skia::canvas::SrcRectConstraint::Strict,
+        ));
+
+        canvas.draw_image_rect_with_sampling_options(
+            image,
+            src_rect,
+            rects.dst_rect,
+            skia::SamplingOptions::new(skia::FilterMode::Linear, skia::MipmapMode::Linear),
+            &paint,
+        );
+
+        // Clip out the rounded corners
+        let border_radius = self.settings().border_radius_px as f32;
+        let rounded_dst_rect =
+            skia::RRect::new_rect_xy(rects.original_dst_rect, border_radius, border_radius);
+
+        canvas.clip_rrect(rounded_dst_rect, skia::ClipOp::Difference, true);
+        canvas.clear(skia::Color::TRANSPARENT);
+
+        Ok(gst::FlowSuccess::Ok)
+    }
+
+    fn reshape_before_transform(&self, inbuf: &gst::BufferRef) {
+        let timestamp = inbuf.pts().expect("Buffer without PTS");
+        let segment = self.obj().segment().downcast::<gst::ClockTime>().ok();
+        let stream_time = segment.as_ref().and_then(|s| s.to_stream_time(timestamp));
+
+        match stream_time {
+            Some(stream_time) => match self.obj().sync_values(stream_time) {
+                Ok(_) => (),
+                Err(err) => {
+                    gst::trace!(CAT, imp = self, "Failed to sync values: {:?}", err);
+                }
+            },
+            None => {
+                gst::trace!(CAT, imp = self, "No stream time available");
+            }
+        }
+    }
+
+    fn reshape_set_caps(
+        &self,
+        incaps: &gst::Caps,
+        outcaps: &gst::Caps,
+    ) -> Result<(), gst::LoggableError> {
+        let (in_info, out_info) = match (
+            gst_video::VideoInfo::from_caps(incaps),
+            gst_video::VideoInfo::from_caps(outcaps),
+        ) {
+            (Ok(in_info), Ok(out_info)) => (in_info, out_info),
+            _ => return Err(gst::loggable_error!(CAT, "Failed to parse output caps")),
+        };
+
+        gst::debug!(
+            CAT,
+            imp = self,
+            "Scaling from {}x{} to {}x{}",
+            in_info.width(),
+            in_info.height(),
+            out_info.width(),
+            out_info.height(),
+        );
+
+        {
+            let mut state = self.state();
+            state.in_info = Some(in_info);
+            state.out_info = Some(out_info);
+        }
+
+        self.parent_set_caps(incaps, outcaps)
+    }
+
+    fn reshape_start(&self) -> Result<(), gst::ErrorMessage> {
+        gst::debug!(CAT, imp = self, "Starting");
+        self.setup_compositor_size();
+        self.parent_start()
+    }
+
+    fn reshape_submit_input_buffer(
+        &self,
+        is_discont: bool,
+        inbuf: gst::Buffer,
+    ) -> Result<gst::FlowSuccess, gst::FlowError> {
+        let (compositor_position, _) = self.frame_composition_info(&inbuf);
+
+        {
+            let mut state = self.state();
+            if state.compositor_position != compositor_position {
+                state.compositor_position = compositor_position;
+                gst::debug!(
+                    CAT,
+                    imp = self,
+                    "Compositor position changed to: {:?}",
+                    state.compositor_position,
+                );
+                drop(state);
+
+                self.obj().reconfigure_src();
+            }
+        }
+
+        self.parent_submit_input_buffer(is_discont, inbuf)
+    }
+
+    fn reshape_copy_metadata(
+        &self,
+        inbuf: &gst::BufferRef,
+        mut_outbuf: &mut gst::BufferRef,
+    ) -> Result<(), gst::LoggableError> {
+        let settings = self.settings();
+        let crop_optimization_enabled = !settings.disable_crop_optimization;
+
+        add_custom_meta(mut_outbuf, settings);
+        add_original_frame_meta(mut_outbuf, inbuf);
+
+        self.parent_copy_metadata(inbuf, mut_outbuf)?;
+
+        // Update FrameCompositionMeta to also have the floored/ceiled values.
+        let compositor_position = self.state().compositor_position;
+        let (mut croppedx, mut croppedy): (f64, f64) = (0.0, 0.0);
+        if let Some(compositor_rect) = compositor_position {
+            let rects = self.compute_src_image_and_dest_rects(None);
+            #[cfg(feature = "ges")]
+            if let Some(mut meta) = mut_outbuf.meta_mut::<ges::prelude::FrameCompositionMeta>() {
+                // We need to floor the x and y values, and ceil the width and height
+                let mut x = compositor_rect.x() as f64;
+                let mut y = compositor_rect.y() as f64;
+                let mut width = compositor_rect.width() as f64;
+                let mut height = compositor_rect.height() as f64;
+
+                if crop_optimization_enabled {
+                    gst::log!(CAT, imp = self, "Big zoom optimization enabled");
+                    if let Ok(rects) = rects {
+                        width = rects.final_position.width() as f64;
+                        height = rects.final_position.height() as f64;
+                        if compositor_rect.left() < 0. {
+                            x = 0.;
+                            croppedx = compositor_rect.left() as f64;
+                        }
+
+                        if compositor_rect.top() < 0. {
+                            y = 0.;
+                            croppedy = compositor_rect.top() as f64;
+                        }
+                    }
+                }
+
+                meta.set_pos_x(x.floor());
+                meta.set_pos_y(y.floor());
+                meta.set_width(width.ceil());
+                meta.set_height(height.ceil());
+            }
+
+            if crop_optimization_enabled {
+                if let Ok(mut meta) = gst::meta::CustomMeta::from_mut_buffer(
+                    mut_outbuf,
+                    "OriginalFrameCompositionMeta",
+                ) {
+                    if let Ok(rects) = rects {
+                        let s = meta.mut_structure();
+
+                        s.set("croppedx", croppedx);
+                        s.set("croppedy", croppedy);
+
+                        // When content is cropped from negative positions, we need to adjust
+                        // for the fractional pixels that were lost in the cropping
+                        let pos_x = if croppedx < 0.0 {
+                            // croppedx is negative, representing content cropped from the left
+                            // We need to add back the fractional part that was lost
+                            rects.original_dst_rect.left() as f64 - croppedx.fract()
+                        } else {
+                            rects.original_dst_rect.left() as f64
+                        };
+
+                        let pos_y = if croppedy < 0.0 {
+                            // croppedy is negative, representing content cropped from the top
+                            // We need to add back the fractional part that was lost
+                            rects.original_dst_rect.top() as f64 - croppedy.fract()
+                        } else {
+                            rects.original_dst_rect.top() as f64
+                        };
+
+                        s.set("posx", pos_x);
+                        s.set("posy", pos_y);
+                        s.set("height", rects.original_dst_rect.height() as f64);
+                        s.set("width", rects.original_dst_rect.width() as f64);
+                    }
+                } else {
+                    gst::debug!(
+                        CAT,
+                        imp = self,
+                        "Failed to get OriginalFrameCompositionMeta"
+                    );
+                }
+            }
+
+            #[cfg(not(feature = "ges"))]
+            {
+                let _ = compositor_rect;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn reshape_transform_caps(
+        &self,
+        direction: gst::PadDirection,
+        caps: &gst::Caps,
+        filter: Option<&gst::Caps>,
+    ) -> Option<gst::Caps> {
+        match direction {
+            gst::PadDirection::Src => {
+                let mut caps = caps.copy();
+                caps.make_mut().map_in_place(move |_features, structure| {
+                    structure.remove_fields(["width", "height"]);
+
+                    std::ops::ControlFlow::Continue(())
+                });
+                self.parent_transform_caps(direction, &caps, filter)
+            }
+            gst::PadDirection::Sink => {
+                let (width, height) = self.compute_output_size(caps);
+
+                if (width, height) == (None, None) {
+                    let mut caps = caps.copy();
+                    let settings = self.settings();
+                    caps.get_mut()
+                        .unwrap()
+                        .map_in_place(move |_features, structure| {
+                            if let Ok(width) = structure.get::<i32>("width") {
+                                structure.set(
+                                    "width",
+                                    width - settings.crop_left - settings.crop_right
+                                        + 2 * settings.padding_px,
+                                );
+                            }
+
+                            if let Ok(height) = structure.get::<i32>("height") {
+                                structure.set(
+                                    "height",
+                                    height - settings.crop_top - settings.crop_top
+                                        + 2 * settings.padding_px,
+                                );
+                            }
+
+                            std::ops::ControlFlow::Continue(())
+                        });
+                    gst::debug!(CAT, imp = self, "Transformed caps: {caps:?}");
+                    return self.parent_transform_caps(direction, &caps, filter);
+                }
+
+                let mut caps = caps.copy();
+                caps.get_mut()
+                    .unwrap()
+                    .map_in_place(move |_features, structure| {
+                        if let Some(ref width) = width {
+                            structure.set("width", width);
+                        }
+
+                        if let Some(ref height) = height {
+                            structure.set("height", height);
+                        }
+
+                        std::ops::ControlFlow::Continue(())
+                    });
+
+                gst::debug!(CAT, imp = self, "Transformed caps: {caps:?}");
+
+                self.parent_transform_caps(direction, &caps, filter)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn frame_composition_info(&self, _buf: &gst::BufferRef) -> (Option<skia::Rect>, f64) {
+        #[cfg(feature = "ges")]
+        {
+            if let Some(meta) = _buf.meta::<ges::prelude::FrameCompositionMeta>() {
+                let padding = self.settings().padding_px as f32;
+                (
+                    Some(skia::Rect::from_xywh(
+                        meta.pos_x() as f32,
+                        meta.pos_y() as f32,
+                        meta.width() as f32 + padding * 2.,
+                        meta.height() as f32 + padding * 2.,
+                    )),
+                    meta.alpha(),
+                )
+            } else {
+                (None, 1.0)
+            }
+        }
+        #[cfg(not(feature = "ges"))]
+        (None, 1.0)
+    }
+
+    #[cfg(not(feature = "ges"))]
+    fn setup_compositor_size(&self) {}
+
+    #[cfg(feature = "ges")]
+    fn setup_compositor_size(&self) {
+        let mut parent = Some(self.obj().clone().upcast::<gst::Object>());
+        while let Some(p) = parent {
+            if let Some(track) = p.downcast_ref::<ges::VideoTrack>() {
+                let mut state = self.state();
+                state.compositor_size = None;
+                if let Some(caps) = track.restriction_caps() {
+                    for structure in caps.iter() {
+                        let (mut width, mut height) = (None, None);
+                        if let Ok(w) = structure.get::<i32>("width") {
+                            width = Some(w);
+                        }
+                        if let Ok(h) = structure.get::<i32>("height") {
+                            height = Some(h);
+                        }
+
+                        if let (Some(w), Some(h)) = (width, height) {
+                            state.compositor_size = Some(skia::Size::new(w as f32, h as f32));
+                        } else {
+                            gst::info!(CAT, "Failed to get width/height from restriction caps");
+                        }
+                    }
+                }
+
+                gst::info!(
+                    CAT,
+                    imp = self,
+                    "Compositor size: {:?}",
+                    state.compositor_size
+                );
+
+                break;
+            }
+
+            parent = p.parent()
+        }
+    }
+
+    fn compute_output_size(&self, caps: &gst::Caps) -> (Option<i32>, Option<i32>) {
+        if let Ok(rects) = self.compute_src_image_and_dest_rects(Some(caps)) {
+            (
+                if rects.final_position.width() <= 0. {
+                    None
+                } else {
+                    Some(rects.final_position.width().ceil() as i32)
+                },
+                if rects.final_position.height() <= 0. {
+                    None
+                } else {
+                    Some(rects.final_position.height().ceil() as i32)
+                },
+            )
+        } else if let Some(rect) = self.state().compositor_position {
+            (
+                Some(rect.width().ceil() as i32),
+                Some(rect.height().ceil() as i32),
+            )
+        } else {
+            (None, None)
+        }
+    }
+
+    fn compute_src_image_and_dest_rects(
+        &self,
+        incaps: Option<&gst::Caps>,
+    ) -> Result<TranslationRects, gst::FlowError> {
+        let state = self.state();
+        let in_info = if let Some(in_info) = state.in_info.as_ref() {
+            in_info.clone()
+        } else if let Some(incaps) = incaps {
+            if !incaps.is_fixed() {
+                return Err(gst::FlowError::NotNegotiated);
+            }
+
+            if let Ok(info) = gst_video::VideoInfo::from_caps(incaps) {
+                info
+            } else {
+                return Err(gst::FlowError::NotNegotiated);
+            }
+        } else {
+            gst::element_imp_error!(self, gst::CoreError::Negotiation, ["Have no state yet"]);
+            return Err(gst::FlowError::NotNegotiated);
+        };
+
+        let compositor_size = state.compositor_size.unwrap_or(skia::Size::new(
+            in_info.width() as f32,
+            in_info.height() as f32,
+        ));
+
+        let out_frame_size = if let Some(out_info) = state.out_info.as_ref() {
+            skia::Size::new(out_info.width() as f32, out_info.height() as f32)
+        } else {
+            compositor_size
+        };
+        let in_frame_size = if let Some(in_info) = state.in_info.as_ref() {
+            skia::Size::new(in_info.width() as f32, in_info.height() as f32)
+        } else {
+            compositor_size
+        };
+
+        let (padding_px, mut src_crop_left, crop_right, mut src_crop_top, crop_bottom) = {
+            let settings = self.settings();
+            (
+                settings.padding_px as f32,
+                settings.crop_left as f32,
+                settings.crop_right as f32,
+                settings.crop_top as f32,
+                settings.crop_bottom as f32,
+            )
+        };
+
+        // We have extended the video frame to get rid of floats in transform_caps,
+        // we will draw the video frame anti-aliassed on the x_offset and y_offset.
+        // Doing it this way means the compositor doesn't need to do any
+        // scaling/anti-aliassing, we already do it here instead.
+        let (
+            mut dst_left,
+            mut dst_top,
+            compositor_rect,
+            img_compositor_rect,
+            _has_compositor_position,
+        ) = if let Some(ref position_in_compositor) = state.compositor_position {
+            let x = position_in_compositor.left();
+            let y = position_in_compositor.top();
+
+            (
+                x - x.floor(),
+                y - y.floor(),
+                *position_in_compositor,
+                skia::Rect::from_xywh(
+                    position_in_compositor.x() + padding_px,
+                    position_in_compositor.y() + padding_px,
+                    position_in_compositor.width() - 2. * padding_px,
+                    position_in_compositor.height() - 2. * padding_px,
+                ),
+                true,
+            )
+        } else {
+            let compositor_rect = skia::Rect::from_xywh(
+                0.,
+                0.,
+                in_frame_size.width + 2. * padding_px as f32,
+                in_frame_size.height + 2. * padding_px as f32,
+            );
+            gst::debug!(
+                CAT,
+                imp = self,
+                "No compositor position set, using compositor rect: {compositor_rect:?}",
+            );
+            (
+                0.0,
+                0.0,
+                compositor_rect,
+                skia::Rect::from_xywh(0., 0., in_frame_size.width, in_frame_size.height),
+                false,
+            )
+        };
+        drop(state);
+
+        let mut src_width = in_info.width() as f32 - crop_right;
+        let mut src_height = in_info.height() as f32 - crop_bottom;
+
+        let mut dst_width = if img_compositor_rect.width() > 0. {
+            img_compositor_rect.width()
+        } else {
+            out_frame_size.width - 2. * padding_px
+        };
+        let mut dst_height = if img_compositor_rect.height() > 0. {
+            img_compositor_rect.height()
+        } else {
+            out_frame_size.height - 2. * padding_px
+        };
+
+        let (mut original_dst_left, mut original_dst_top) = (dst_left, dst_top);
+        let (original_dst_width, original_dst_height) = (dst_width, dst_height);
+
+        let (out_x, out_y) = (compositor_rect.x(), compositor_rect.y());
+        let (mut out_width, mut out_height) = (compositor_rect.width(), compositor_rect.height());
+
+        let crop_optimization_enabled = !self.settings().disable_crop_optimization;
+
+        if crop_optimization_enabled {
+            let width_factor = (in_info.width() as f32) / dst_width;
+            let height_factor = in_info.height() as f32 / dst_height;
+
+            if img_compositor_rect.left() < 0. {
+                let extra_crop_left_src = img_compositor_rect.left() * width_factor;
+
+                src_crop_left -= extra_crop_left_src;
+                dst_width += img_compositor_rect.left();
+
+                original_dst_left += img_compositor_rect.left();
+                out_width += compositor_rect.left();
+            } else if compositor_rect.left() < 0. {
+                dst_left += img_compositor_rect.left();
+                original_dst_left += img_compositor_rect.left();
+
+                out_width += compositor_rect.left();
+            } else {
+                dst_left += padding_px;
+                original_dst_left += padding_px;
+            }
+
+            if img_compositor_rect.right() > compositor_size.width {
+                let cropped = compositor_size.width - img_compositor_rect.right();
+                let extra_crop_right = cropped * width_factor;
+
+                src_width += extra_crop_right;
+                dst_width += cropped;
+            }
+
+            if compositor_rect.right() > compositor_size.width {
+                out_width += compositor_size.width - compositor_rect.right();
+            }
+
+            if img_compositor_rect.top() < 0. {
+                let extra_crop_top = img_compositor_rect.top() * height_factor;
+
+                src_crop_top -= extra_crop_top;
+                dst_height += img_compositor_rect.top();
+                original_dst_top += img_compositor_rect.top();
+                out_height += compositor_rect.top();
+            } else if compositor_rect.top() < 0. {
+                dst_top += compositor_rect.top() + padding_px;
+                original_dst_top += compositor_rect.top() + padding_px;
+                out_height += compositor_rect.top();
+            } else {
+                dst_top += padding_px;
+                original_dst_top += padding_px;
+            }
+
+            if img_compositor_rect.bottom() > compositor_size.height {
+                let cropped = compositor_size.height - img_compositor_rect.bottom();
+                let extra_crop_bottom = cropped * height_factor;
+
+                src_height += extra_crop_bottom;
+                dst_height += cropped;
+            }
+
+            if compositor_rect.bottom() > compositor_size.height {
+                out_height += compositor_size.height - compositor_rect.bottom();
+            }
+        } else {
+            dst_left += padding_px;
+            dst_top += padding_px;
+
+            original_dst_left += padding_px;
+            original_dst_top += padding_px;
+        }
+
+        let src_with_cropping_applied =
+            skia::Rect::from_ltrb(src_crop_left, src_crop_top, src_width, src_height);
+
+        if dst_top < 1.0 {
+            dst_top = 0.0;
+        }
+        if dst_left < 1.0 {
+            dst_left = 0.0;
+        }
+        let dst_rect = skia::Rect::from_xywh(dst_left, dst_top, dst_width, dst_height);
+
+        let original_dst_rect = skia::Rect::from_xywh(
+            original_dst_left,
+            original_dst_top,
+            original_dst_width,
+            original_dst_height,
+        );
+
+        Ok(TranslationRects {
+            src_with_cropping_applied,
+            dst_rect,
+            original_dst_rect,
+            final_position: skia::Rect::from_xywh(out_x, out_y, out_width, out_height),
+        })
+    }
+}
+
+pub fn add_custom_meta(outbuf: &mut gst::BufferRef, settings: std::sync::MutexGuard<'_, Settings>) {
+    let mut meta = if let Ok(meta) = gst::meta::CustomMeta::add(outbuf, "RoundedCornersFrameMeta") {
+        meta
+    } else {
+        gst::info!(CAT, "RoundedCornersFrameMeta not registered");
+        return;
+    };
+    let s = meta.mut_structure();
+    s.set("border-radius-px", settings.border_radius_px);
+    s.set("corner-smoothing-pct", settings.corner_smoothing_pct);
+}
+
+pub fn add_original_frame_meta(outbuf: &mut gst::BufferRef, inbuf: &gst::BufferRef) {
+    #[cfg(feature = "ges")]
+    {
+        if let Some(meta) = inbuf.meta::<ges::prelude::FrameCompositionMeta>() {
+            let mut new_meta = if let Ok(new_meta) =
+                gst::meta::CustomMeta::add(outbuf, "OriginalFrameCompositionMeta")
+            {
+                new_meta
+            } else {
+                gst::info!(CAT, "OriginalFrameCompositionMeta not registered");
+                return;
+            };
+            let s = new_meta.mut_structure();
+            s.set("alpha", meta.alpha());
+            s.set("posx", meta.pos_x());
+            s.set("posy", meta.pos_y());
+            s.set("height", meta.height());
+            s.set("width", meta.width());
+            s.set("zorder", meta.zorder());
+            s.set("operator", meta.operator());
+            gst::trace!(CAT, "OriginalFrameCompositionMeta: {:#?}", s);
+        }
+    }
+    #[cfg(not(feature = "ges"))]
+    {
+        let _ = (outbuf, inbuf);
+    }
+}

--- a/video/skia/src/reshapegl/imp.rs
+++ b/video/skia/src/reshapegl/imp.rs
@@ -1,0 +1,438 @@
+use gst::{glib, subclass::prelude::*};
+use gst_base::subclass::prelude::*;
+use gst_gl::{
+    prelude::*,
+    subclass::{prelude::*, GLFilterMode},
+    *,
+};
+use tracing::instrument;
+
+use std::sync::{LazyLock, Mutex};
+
+use crate::reshape_common::{ReshapeCommon, Settings, State};
+
+static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
+    gst::DebugCategory::new(
+        "skiareshapegl",
+        gst::DebugColorFlags::empty(),
+        Some("Reshape video with skia using GL"),
+    )
+});
+
+#[derive(Debug, Clone)]
+struct SkContext(skia::gpu::DirectContext);
+
+// SAFETY: All access to the GL interface happens from the GstGLContext thread
+unsafe impl Send for SkContext {}
+unsafe impl Sync for SkContext {}
+
+#[derive(Default, Debug)]
+pub struct SkiaReshapeGL {
+    settings: Mutex<Settings>,
+    state: Mutex<State>,
+    context: Mutex<Option<SkContext>>,
+    gstglcontext: Mutex<Option<gst_gl::GLContext>>,
+}
+
+impl ReshapeCommon for SkiaReshapeGL {
+    fn settings(&self) -> std::sync::MutexGuard<'_, Settings> {
+        self.settings.lock().unwrap()
+    }
+
+    fn state(&self) -> std::sync::MutexGuard<'_, State> {
+        self.state.lock().unwrap()
+    }
+}
+
+impl SkiaReshapeGL {
+    fn render_with_skia(
+        &self,
+        skia_context: &mut skia::gpu::DirectContext,
+        input_tex_id: u32,
+        output_tex_id: u32,
+        in_info: &gst_video::VideoInfo,
+        out_info: &gst_video::VideoInfo,
+    ) -> Result<(), gst::LoggableError> {
+        gst::debug!(
+            CAT,
+            imp = self,
+            "Starting Skia rendering - Frame processing"
+        );
+
+        gst::log!(
+            CAT,
+            "Creating input backend texture from GL texture ID {} ({}x{})",
+            input_tex_id,
+            in_info.width(),
+            in_info.height()
+        );
+
+        let input_backend_texture = crate::gl::create_backend_texture_from_gl(
+            input_tex_id,
+            in_info.width() as i32,
+            in_info.height() as i32,
+            in_info.format(),
+        )?;
+
+        gst::log!(
+            CAT,
+            "Creating output backend texture from GL texture ID {} ({}x{})",
+            output_tex_id,
+            out_info.width(),
+            out_info.height()
+        );
+
+        let output_backend_texture = crate::gl::create_backend_texture_from_gl(
+            output_tex_id,
+            out_info.width() as i32,
+            out_info.height() as i32,
+            out_info.format(),
+        )?;
+
+        let mut out_surface = crate::gl::create_surface_from_backend_texture(
+            skia_context,
+            &output_backend_texture,
+            out_info.format(),
+        )?;
+
+        // Create the Skia image with standard properties but comprehensive error checking
+        let image = skia::Image::from_texture(
+            skia_context,
+            &input_backend_texture,
+            skia::gpu::SurfaceOrigin::TopLeft,
+            self.video_format_to_skia_color_type(in_info.format())
+                .ok_or_else(|| gst::loggable_error!(CAT, "Unsupported input format"))?,
+            skia::AlphaType::Unpremul,
+            None, // FIXME, What does that colorspace represent exactly here?
+        )
+        .ok_or_else(|| gst::loggable_error!(CAT, "Failed to create image from backend texture"))?;
+
+        if skia_context.abandoned() {
+            return Err(gst::loggable_error!(CAT, "Skia context has been abandoned"));
+        }
+
+        if !image.is_valid(&mut *skia_context) {
+            return Err(gst::loggable_error!(CAT, "Input image is invalid"));
+        }
+
+        let canvas = out_surface.canvas();
+        self.reshape(canvas, &image)
+            .map_err(|e| gst::loggable_error!(CAT, "Failed to reshape: {}", e))?;
+
+        /* Execute the drawing commands and submit them to the GPU */
+        skia_context.flush_and_submit();
+
+        Ok(())
+    }
+
+    fn video_format_to_skia_color_type(
+        &self,
+        format: gst_video::VideoFormat,
+    ) -> Option<skia::ColorType> {
+        let color_type = match format {
+            gst_video::VideoFormat::Rgba => Some(skia::ColorType::RGBA8888),
+            gst_video::VideoFormat::Bgra => Some(skia::ColorType::BGRA8888),
+            gst_video::VideoFormat::Rgb => Some(skia::ColorType::RGB888x),
+            _ => None,
+        };
+
+        gst::debug!(
+            CAT,
+            "GStreamer format {:?} -> Skia ColorType {:?}",
+            format,
+            color_type
+        );
+        color_type
+    }
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for SkiaReshapeGL {
+    const NAME: &'static str = "GstSkiaReshapeGL";
+    type Type = super::SkiaReshapeGL;
+    type ParentType = gst_gl::GLFilter;
+}
+
+impl ObjectImpl for SkiaReshapeGL {
+    fn properties() -> &'static [glib::ParamSpec] {
+        static PROPERTIES: LazyLock<Vec<glib::ParamSpec>> =
+            LazyLock::new(crate::reshape_common::reshape_properties);
+        PROPERTIES.as_ref()
+    }
+
+    fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        self.reshape_property(_id, pspec)
+    }
+
+    fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+        self.reshape_set_property(_id, value, pspec)
+    }
+}
+
+impl GstObjectImpl for SkiaReshapeGL {}
+
+impl ElementImpl for SkiaReshapeGL {
+    fn metadata() -> Option<&'static gst::subclass::ElementMetadata> {
+        static ELEMENT_METADATA: LazyLock<gst::subclass::ElementMetadata> = LazyLock::new(|| {
+            gst::subclass::ElementMetadata::new(
+                "SkiaReshapeGL",
+                "Filter/Effect/Converter/Video",
+                "Applies geometric transformations (rounded corners, scaling, cropping) to video frames using Skia with GL acceleration",
+                "Thibault Saunier <tsaunier@igalia.com>",
+            )
+        });
+
+        Some(&*ELEMENT_METADATA)
+    }
+}
+impl BaseTransformImpl for SkiaReshapeGL {
+    const MODE: gst_base::subclass::BaseTransformMode =
+        gst_base::subclass::BaseTransformMode::NeverInPlace;
+    const PASSTHROUGH_ON_SAME_CAPS: bool = false;
+    const TRANSFORM_IP_ON_PASSTHROUGH: bool = false;
+
+    fn start(&self) -> Result<(), gst::ErrorMessage> {
+        self.reshape_start()
+    }
+
+    fn set_caps(&self, incaps: &gst::Caps, outcaps: &gst::Caps) -> Result<(), gst::LoggableError> {
+        self.reshape_set_caps(incaps, outcaps)
+    }
+
+    fn transform_caps(
+        &self,
+        direction: gst::PadDirection,
+        caps: &gst::Caps,
+        filter: Option<&gst::Caps>,
+    ) -> Option<gst::Caps> {
+        self.reshape_transform_caps(direction, caps, filter)
+    }
+
+    fn submit_input_buffer(
+        &self,
+        is_discont: bool,
+        inbuf: gst::Buffer,
+    ) -> Result<gst::FlowSuccess, gst::FlowError> {
+        self.reshape_submit_input_buffer(is_discont, inbuf)
+    }
+
+    fn copy_metadata(
+        &self,
+        inbuf: &gst::BufferRef,
+        outbuf: &mut gst::BufferRef,
+    ) -> Result<(), gst::LoggableError> {
+        self.reshape_copy_metadata(inbuf, outbuf)
+    }
+
+    fn before_transform(&self, inbuf: &gst::BufferRef) {
+        self.reshape_before_transform(inbuf)
+    }
+}
+impl GLBaseFilterImpl for SkiaReshapeGL {
+    fn gl_set_caps(
+        &self,
+        incaps: &gst::Caps,
+        outcaps: &gst::Caps,
+    ) -> Result<(), gst::LoggableError> {
+        let in_info = gst_video::VideoInfo::from_caps(incaps)
+            .map_err(|_| gst::loggable_error!(CAT, "Failed to parse input caps"))?;
+        let out_info = gst_video::VideoInfo::from_caps(outcaps)
+            .map_err(|_| gst::loggable_error!(CAT, "Failed to parse output caps"))?;
+
+        gst::debug!(
+            CAT,
+            imp = self,
+            "Setting caps: {}x{} -> {}x{}",
+            in_info.width(),
+            in_info.height(),
+            out_info.width(),
+            out_info.height()
+        );
+
+        {
+            let mut state = self.state.lock().unwrap();
+            state.in_info = Some(in_info);
+            state.out_info = Some(out_info);
+        }
+
+        self.parent_gl_set_caps(incaps, outcaps)
+    }
+
+    fn gl_start(&self) -> Result<(), gst::LoggableError> {
+        gst::debug!(CAT, imp = self, "Starting GL operations");
+
+        let filter = self.obj();
+
+        // Create a shader when GL is started, knowing that the OpenGL context is
+        // available.
+        let context = match GLBaseFilterExt::context(&*filter) {
+            Some(ctx) => ctx,
+            None => {
+                gst::error!(CAT, imp = self, "No GL context available");
+                return Err(gst::loggable_error!(CAT, "No GL context available"));
+            }
+        };
+
+        // FIXME: Implement support for other platforms, there is no good reason
+        // why it doesn't work
+        if context.gl_platform() != gst_gl::GLPlatform::EGL {
+            return Err(gst::loggable_error!(CAT, "Only EGL platform is supported."));
+        }
+
+        let display = context.display();
+        let our_context = gst_gl::GLContext::new(&display);
+
+        our_context
+            .create(Some(&context))
+            .map_err(|e| gst::loggable_error!(CAT, "Couldn't start our context {e:?}."))?;
+        gst::log!(CAT, imp = self, "Created our own {:?}", context);
+
+        let gl_result: std::sync::Arc<std::sync::Mutex<Result<(), gst::LoggableError>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Ok(())));
+        our_context.thread_add(glib::clone!(
+            #[to_owned(rename_to = this)]
+            self,
+            #[strong]
+            gl_result,
+            move |context| {
+                if let Some(gl_interface) = skia::gpu::gl::Interface::new_load_with(|name| {
+                    context.proc_address(name) as *const std::ffi::c_void
+                }) {
+                    if let Some(direct_context) =
+                        skia::gpu::direct_contexts::make_gl(gl_interface, None)
+                    {
+                        *this.context.lock().unwrap() = Some(SkContext(direct_context));
+                        *this.gstglcontext.lock().unwrap() = Some(context.clone());
+                        gst::debug!(CAT, imp = self, "Created Skia GL context");
+                    } else {
+                        *gl_result.lock().unwrap() = Err(gst::loggable_error!(
+                            CAT,
+                            "Failed to create Skia GL direct context"
+                        ));
+                        return;
+                    }
+                } else {
+                    *gl_result.lock().unwrap() = Err(gst::loggable_error!(
+                        CAT,
+                        "Failed to create Skia GL direct context"
+                    ));
+                    return;
+                }
+
+                gst::debug!(CAT, imp = self, "Successfully created Skia GL context pair");
+            }
+        ));
+
+        gl_result.lock().unwrap().clone()?;
+
+        self.parent_gl_start()
+    }
+
+    fn gl_stop(&self) {
+        gst::debug!(CAT, imp = self, "Stopping GL operations");
+
+        self.parent_gl_stop();
+
+        *self.context.lock().unwrap() = None;
+    }
+}
+
+impl GLFilterImpl for SkiaReshapeGL {
+    const MODE: GLFilterMode = GLFilterMode::Texture;
+
+    fn transform_internal_caps(
+        &self,
+        _direction: gst::PadDirection,
+        caps: &gst::Caps,
+        _filter: Option<&gst::Caps>,
+    ) -> Option<gst::Caps> {
+        Some(caps.clone())
+    }
+
+    #[instrument(skip(self))]
+    fn filter_texture(
+        &self,
+        input: &gst_gl::GLMemory,
+        output: &gst_gl::GLMemory,
+    ) -> Result<(), gst::LoggableError> {
+        gst::trace!(CAT, imp = self, "Processing GL texture");
+
+        let state = self.state.lock().unwrap();
+        let in_info = state
+            .in_info
+            .as_ref()
+            .ok_or_else(|| gst::loggable_error!(CAT, "No input info available"))?
+            .clone();
+        let out_info = state
+            .out_info
+            .as_ref()
+            .ok_or_else(|| gst::loggable_error!(CAT, "No output info available"))?
+            .clone();
+        drop(state);
+
+        // Get input and output texture IDs
+        let input_tex_id = input.texture_id();
+        let output_tex_id = output.texture_id();
+
+        let in_info = in_info.clone();
+        let out_info = out_info.clone();
+        let gl_result: std::sync::Arc<std::sync::Mutex<Result<(), gst::LoggableError>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Ok(())));
+        self.gstglcontext
+            .lock()
+            .unwrap()
+            .as_ref()
+            .expect("No dedicated GL context available")
+            .thread_add(glib::clone!(
+                #[weak(rename_to = this)]
+                self,
+                #[strong]
+                gl_result,
+                move |context| {
+                    if let Err(err) = context.activate(true) {
+                        *gl_result.lock().unwrap() = Err(gst::loggable_error!(CAT, "{err:?}",));
+                        return;
+                    }
+                    gst::debug!(
+                        CAT,
+                        "EXECUTING SKIA RENDERING IN DEDICATED CONTEXT: {:?}",
+                        context
+                    );
+
+                    let skia_context_mutex = this.context.lock().unwrap();
+                    let mut skia_context = skia_context_mutex
+                        .as_ref()
+                        .expect("No Skia context while filtering texture")
+                        .clone();
+
+                    // Call render_with_skia in the dedicated context
+                    let render_result = this.render_with_skia(
+                        &mut skia_context.0,
+                        input_tex_id,
+                        output_tex_id,
+                        &in_info,
+                        &out_info,
+                    );
+
+                    match render_result {
+                        Ok(_) => {
+                            gst::debug!(
+                                CAT,
+                                "Skia rendering completed successfully in dedicated context"
+                            );
+                        }
+                        Err(e) => {
+                            *gl_result.lock().unwrap() = Err(e);
+                        }
+                    }
+                    if let Err(err) = context.activate(false) {
+                        *gl_result.lock().unwrap() = Err(gst::loggable_error!(CAT, "{err:?}",));
+                        return;
+                    }
+                }
+            ));
+
+        let result = gl_result.lock().unwrap().clone();
+        result
+    }
+}

--- a/video/skia/src/reshapegl/mod.rs
+++ b/video/skia/src/reshapegl/mod.rs
@@ -1,0 +1,31 @@
+// Copyright (C) 2025, Thibault Saunier <tsaunier@igalia.com>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v2.0.
+// If a copy of the MPL was not distributed with this file, You can obtain one at
+// <https://mozilla.org/MPL/2.0/>.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use gst::glib;
+use gst::prelude::*;
+
+mod imp;
+
+glib::wrapper! {
+    pub struct SkiaReshapeGL(ObjectSubclass<imp::SkiaReshapeGL>) @extends gst_gl::GLFilter, gst_gl::GLBaseFilter, gst_base::BaseTransform, gst::Element, gst::Object;
+}
+
+impl SkiaReshapeGL {
+    pub fn new(name: Option<&str>) -> Self {
+        glib::Object::builder().property("name", name).build()
+    }
+}
+
+pub fn register(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
+    gst::Element::register(
+        Some(plugin),
+        "skiareshapegl",
+        gst::Rank::NONE,
+        SkiaReshapeGL::static_type(),
+    )
+}


### PR DESCRIPTION
- **cargo_wrapper: Reindent and cleanup**
  This commit should go into a new .git-blame-ignore-revs file when we have the
  final hash

  Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/2471>

- **cargo_wrapper: Fix log file name**
  We were using the same log files for bins and plugins

  Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/2471>

- **cargo_wrapper: Ignore stale dep files from previous branch builds**
  When switching between branches that have different plugins or dependencies,
  stale .d files from the previous branch can cause cargo to be unnecessarily
  invoked on every build, even when no actual changes have been made.

  This fix checks the modification time of dependency files against the current
  build start time and ignores any .d files that weren't generated during the
  current cargo run. This prevents spurious rebuilds when switching between
  branches with different plugin configurations.

  Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/2471>

- **cargo_wrapper: Fix depfile generation for binaries and add debug logging**
  The depfile generation was only handling lib.rs files, missing main.rs
  files used by binary crates. This caused incomplete dependency tracking
  for binary targets.

  Also added debug logging to help diagnose issues with Cargo.toml
  detection and stripped whitespace from source paths to handle parsing
  edge cases.

  Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/2471>

- **cargo_wrapper: Fix mismatched quotes causing SyntaxError**
  Fixes https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/2471#note_3077591

  Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/2529>

- **meson: Isolate built plugins from cargo target directory**
  Move plugin building to a plugins/ subdirectory to prevent the GStreamer
  registry from recursively scanning into the cargo target/ directory tree.
  This fixes an issue where the registry would cache plugins from both
  debug and release builds when switching between build types (which leads
  to not understanding why newly built changes were not taken into account).

  This ensures GST_PLUGIN_PATH only includes the isolated plugins directory,
  preventing stale plugin entries in the registry when switching configurations
  and it has the advantage of speeding up the plugins scanning process.

  Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/2519>

- **cargo_wrapper: Fix mismatched quotes causing SyntaxError**
- **meson: Fix .pc files installation and simplify build output handling**
  The previous implementation used a custom_target with an empty Python
  command to install .pc files, which was a workaround for Meson limitations.

  This commit properly integrates .pc file generation into the main build
  process by:
  - Adding .pc files directly to the output array alongside plugin libraries
  - Using the same rs_plugins custom_target to handle both plugins and .pc files
  - Installing files to their appropriate directories using install_dirs array
  - Filtering out .pc files when building the plugins list for static linking

  This simplifies the build system and ensures .pc files are always installed
  correctly when plugins are built.

- **uridecodepool: Recurse bus message to the current target**
  Even when a bus has been set to the pool to forward contexts,
  etc, passing the messages to the target and its parent is useful.

- **skiareshape: Take into account cropped fractional pixels in the original frame dimensions**
- **skia: Factor out skiareshape common feature into a dedicated trait**
  This way we will be able to reuse all its logic for different backends like
  OpenGL or vulkan

- **skia: Implement a GL version of the skiareshape element**
- **fixup! fixup! skia: Implement a video compositor using skia**