### PR TITLE
skiareshapegl: fix greyish transparency in GL compositing

### DIFF
--- a/video/skia/src/reshape_common.rs
+++ b/video/skia/src/reshape_common.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "ges")]
 use ges::prelude::*;
 use gst::glib;
+use gst::prelude::*;
+use gst_base::prelude::*;
 use gst_video::subclass::prelude::*;
 use skia;
 
@@ -318,7 +320,12 @@ pub trait ReshapeCommon: BaseTransformImpl + ObjectImpl {
         let context_boxed = crate::SkiaContext::new(direct);
         self.obj().emit_by_name::<()>(
             "draw",
-            &[buffer, &video_info, &canvas_boxed, &context_boxed],
+            &[
+                buffer as &dyn glib::value::ToValue,
+                video_info as &dyn glib::value::ToValue,
+                &canvas_boxed as &dyn glib::value::ToValue,
+                &context_boxed as &dyn glib::value::ToValue,
+            ],
         );
 
         Ok(gst::FlowSuccess::Ok)

--- a/video/skia/src/reshapegl/imp.rs
+++ b/video/skia/src/reshapegl/imp.rs
@@ -122,11 +122,38 @@ impl SkiaReshapeGL {
             return Err(gst::loggable_error!(CAT, "Input image is invalid"));
         }
 
+        // Skia GPU surfaces always produce premultiplied alpha, but GStreamer's
+        // only works with unpremultiplied alpha. Wrap the render
+        // in a save_layer with a SkSL unpremultiply ImageFilter + BlendMode::Src
+        // so the layer restore writes straight-alpha values to the output texture.
+        let unpremul_effect = skia::RuntimeEffect::make_for_shader(
+            "uniform shader child; \
+             half4 main(float2 coord) { \
+               half4 c = child.eval(coord); \
+               if (c.a > 0.0) { return half4(c.rgb / c.a, c.a); } \
+               return c; \
+             }",
+            None,
+        )
+        .map_err(|e| gst::loggable_error!(CAT, "SkSL compile error: {}", e))?;
+
+        let builder = skia::runtime_effect::RuntimeShaderBuilder::new(unpremul_effect);
+        let unpremul_filter = skia::image_filters::runtime_shader(&builder, "child", None)
+            .ok_or_else(|| {
+                gst::loggable_error!(CAT, "Failed to create unpremultiply image filter")
+            })?;
+
+        let mut layer_paint = skia::Paint::default();
+        layer_paint.set_blend_mode(skia::BlendMode::Src);
+        layer_paint.set_image_filter(unpremul_filter);
+
         let canvas = out_surface.canvas();
+        canvas.save_layer(&skia::canvas::SaveLayerRec::default().paint(&layer_paint));
+
         self.reshape(buffer, video_info, canvas, &image, Some(skia_context))
             .map_err(|e| gst::loggable_error!(CAT, "Failed to reshape: {}", e))?;
 
-        /* Execute the drawing commands and submit them to the GPU */
+        canvas.restore();
         skia_context.flush_and_submit();
 
         Ok(())

--- a/video/skia/tests/skiareshape_gl_transparency.rs
+++ b/video/skia/tests/skiareshape_gl_transparency.rs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// Minimal reproducer for the GL transparency bug.
+//
+// 2 layers composited via glvideomixer:
+//   0: Solid purple background (videotestsrc)
+//   1: Transparent input → skiareshapegl with draw signal (draws a small rect)
+//
+// The transparent areas of layer 1 should be fully see-through, but instead
+// appear greyish when rendered through GL.
+
+use gst::glib;
+use gst::prelude::*;
+
+fn init() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        gst::init().unwrap();
+        gstskia::plugin_register_static().unwrap();
+    });
+}
+
+fn draw_subtitle_backdrop(args: &[glib::Value]) -> Option<glib::Value> {
+    let video_info = args[2]
+        .get::<gst_video::VideoInfo>()
+        .expect("arg 2 is VideoInfo");
+    let canvas_boxed = args[3]
+        .get::<gstskia::SkiaCanvas>()
+        .expect("arg 3 is SkiaCanvas");
+    let context_boxed = args[4]
+        .get::<gstskia::SkiaContext>()
+        .expect("arg 4 is SkiaContext");
+
+    let canvas = unsafe { canvas_boxed.as_ref() };
+    let direct_context = unsafe { context_boxed.as_mut() };
+
+    let width = video_info.width() as i32;
+    let height = video_info.height() as i32;
+
+    let image_info = skia::ImageInfo::new_n32_premul((width, height), None);
+    let mut surface = if let Some(ctx) = direct_context {
+        skia::gpu::surfaces::render_target(
+            ctx,
+            skia::gpu::Budgeted::Yes,
+            &image_info,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_or_else(|| skia::surfaces::raster(&image_info, None, None).unwrap())
+    } else {
+        skia::surfaces::raster(&image_info, None, None).unwrap()
+    };
+
+    let w = width as f32;
+    let h = height as f32;
+
+    let box_width = w * 0.5;
+    let box_height = h * 0.08;
+    let box_left = (w - box_width) / 2.0;
+    let box_top = h * 0.82;
+    let border_radius = 12.0;
+
+    let rect = skia::Rect::from_xywh(box_left, box_top, box_width, box_height);
+
+    surface.canvas().save_layer_alpha(None, 255);
+
+    // Shadow
+    {
+        let shadow_rect =
+            skia::Rect::from_xywh(box_left, box_top + 20.0, box_width, box_height);
+
+        let mut shadow_paint = skia::Paint::default();
+        shadow_paint.set_color(skia::Color::from_argb(25, 0, 0, 0));
+        shadow_paint.set_anti_alias(true);
+        shadow_paint.set_mask_filter(skia::MaskFilter::blur(
+            skia::BlurStyle::Normal,
+            12.5,
+            false,
+        ));
+        surface
+            .canvas()
+            .draw_round_rect(shadow_rect, border_radius, border_radius, &shadow_paint);
+    }
+
+    // Backdrop
+    {
+        let mut bg_paint = skia::Paint::default();
+        bg_paint.set_color(skia::Color::from_argb(25, 255, 255, 255));
+        bg_paint.set_anti_alias(true);
+        surface
+            .canvas()
+            .draw_round_rect(rect, border_radius, border_radius, &bg_paint);
+    }
+
+    surface.canvas().restore();
+
+    let image = surface.image_snapshot();
+
+    let mut composite_paint = skia::Paint::default();
+    composite_paint.set_blend_mode(skia::BlendMode::SrcOver);
+    canvas.draw_image(&image, (0.0, 0.0), Some(&composite_paint));
+
+    None
+}
+
+#[test]
+fn test_gl_transparency() {
+    init();
+
+    let pipeline = gst::Pipeline::new();
+
+    let mix = gst::ElementFactory::make("glvideomixer")
+        .name("mix")
+        .build()
+        .unwrap();
+    let gldownload = gst::ElementFactory::make("gldownload")
+        .build()
+        .unwrap();
+    let videoconvert = gst::ElementFactory::make("videoconvert")
+        .build()
+        .unwrap();
+    let jpegenc = gst::ElementFactory::make("jpegenc").build().unwrap();
+    let filesink = gst::ElementFactory::make("filesink")
+        .property("location", "/tmp/gl_transparency_minimal.jpg")
+        .build()
+        .unwrap();
+
+    pipeline
+        .add_many([&mix, &gldownload, &videoconvert, &jpegenc, &filesink])
+        .unwrap();
+    gst::Element::link_many([&mix, &gldownload, &videoconvert, &jpegenc, &filesink])
+        .unwrap();
+
+    // Source 0: solid purple background
+    let bg_src = gst::ElementFactory::make("videotestsrc")
+        .property_from_str("pattern", "solid-color")
+        .property("foreground-color", 0xFFDED5F5u32)
+        .property("num-buffers", 1i32)
+        .build()
+        .unwrap();
+    let bg_capsfilter = gst::ElementFactory::make("capsfilter")
+        .property(
+            "caps",
+            &gst_video::VideoCapsBuilder::new()
+                .format(gst_video::VideoFormat::Rgba)
+                .width(320)
+                .height(240)
+                .framerate(gst::Fraction::new(1, 1))
+                .build(),
+        )
+        .build()
+        .unwrap();
+    let bg_upload = gst::ElementFactory::make("glupload").build().unwrap();
+    let bg_colorconvert = gst::ElementFactory::make("glcolorconvert").build().unwrap();
+
+    pipeline
+        .add_many([&bg_src, &bg_capsfilter, &bg_upload, &bg_colorconvert])
+        .unwrap();
+    gst::Element::link_many([&bg_src, &bg_capsfilter, &bg_upload, &bg_colorconvert])
+        .unwrap();
+
+    let bg_pad = mix.request_pad_simple("sink_%u").unwrap();
+    bg_pad.set_property("zorder", 1u32);
+    bg_pad.set_property("width", 320i32);
+    bg_pad.set_property("height", 240i32);
+    bg_colorconvert
+        .static_pad("src")
+        .unwrap()
+        .link(&bg_pad)
+        .unwrap();
+
+    // Source 1: transparent input → skiareshapegl with draw signal
+    let sub_src = gst::ElementFactory::make("videotestsrc")
+        .property_from_str("pattern", "solid-color")
+        .property("foreground-color", 0x00000000u32)
+        .property("num-buffers", 1i32)
+        .build()
+        .unwrap();
+    let sub_capsfilter = gst::ElementFactory::make("capsfilter")
+        .property(
+            "caps",
+            &gst_video::VideoCapsBuilder::new()
+                .format(gst_video::VideoFormat::Rgba)
+                .width(320)
+                .height(240)
+                .framerate(gst::Fraction::new(1, 1))
+                .build(),
+        )
+        .build()
+        .unwrap();
+    let sub_upload = gst::ElementFactory::make("glupload").build().unwrap();
+    let sub_colorconvert = gst::ElementFactory::make("glcolorconvert").build().unwrap();
+    let reshape = gst::ElementFactory::make("skiareshapegl")
+        .name("reshape")
+        .build()
+        .unwrap();
+
+    pipeline
+        .add_many([&sub_src, &sub_capsfilter, &sub_upload, &sub_colorconvert, &reshape])
+        .unwrap();
+    gst::Element::link_many([
+        &sub_src,
+        &sub_capsfilter,
+        &sub_upload,
+        &sub_colorconvert,
+        &reshape,
+    ])
+    .unwrap();
+
+    let sub_pad = mix.request_pad_simple("sink_%u").unwrap();
+    sub_pad.set_property("zorder", 2u32);
+    sub_pad.set_property("width", 320i32);
+    sub_pad.set_property("height", 240i32);
+    reshape
+        .static_pad("src")
+        .unwrap()
+        .link(&sub_pad)
+        .unwrap();
+
+    reshape.connect("draw", false, draw_subtitle_backdrop);
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("Failed to set pipeline to Playing");
+
+    let bus = pipeline.bus().unwrap();
+    for msg in bus.iter_timed(gst::ClockTime::from_seconds(10)) {
+        match msg.view() {
+            gst::MessageView::Eos(..) => break,
+            gst::MessageView::Error(err) => {
+                eprintln!(
+                    "Error from {:?}: {} ({:?})",
+                    err.src().map(|s| s.path_string()),
+                    err.error(),
+                    err.debug()
+                );
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    pipeline
+        .set_state(gst::State::Null)
+        .expect("Failed to set pipeline to Null");
+
+    println!("Done — inspect /tmp/gl_transparency_minimal.jpg");
+}

--- a/video/skia/tests/skiareshape_sw_transparency.rs
+++ b/video/skia/tests/skiareshape_sw_transparency.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MPL-2.0
+//
+// Software-only minimal reproducer for comparison with GL transparency test.
+//
+// 2 layers composited via skiacompositor (no GL):
+//   0: Solid purple background (videotestsrc)
+//   1: Transparent input → skiareshape with draw signal (subtitle backdrop)
+
+use gst::glib;
+use gst::prelude::*;
+
+fn init() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        gst::init().unwrap();
+        gstskia::plugin_register_static().unwrap();
+    });
+}
+
+fn draw_subtitle_backdrop(args: &[glib::Value]) -> Option<glib::Value> {
+    let video_info = args[2]
+        .get::<gst_video::VideoInfo>()
+        .expect("arg 2 is VideoInfo");
+    let canvas_boxed = args[3]
+        .get::<gstskia::SkiaCanvas>()
+        .expect("arg 3 is SkiaCanvas");
+
+    let canvas = unsafe { canvas_boxed.as_ref() };
+
+    let width = video_info.width() as i32;
+    let height = video_info.height() as i32;
+
+    let image_info = skia::ImageInfo::new_n32_premul((width, height), None);
+    let mut surface = skia::surfaces::raster(&image_info, None, None).unwrap();
+
+    let w = width as f32;
+    let h = height as f32;
+
+    let box_width = w * 0.5;
+    let box_height = h * 0.08;
+    let box_left = (w - box_width) / 2.0;
+    let box_top = h * 0.82;
+    let border_radius = 12.0;
+
+    let rect = skia::Rect::from_xywh(box_left, box_top, box_width, box_height);
+
+    surface.canvas().save_layer_alpha(None, 255);
+
+    // Shadow
+    {
+        let shadow_rect =
+            skia::Rect::from_xywh(box_left, box_top + 20.0, box_width, box_height);
+
+        let mut shadow_paint = skia::Paint::default();
+        shadow_paint.set_color(skia::Color::from_argb(25, 0, 0, 0));
+        shadow_paint.set_anti_alias(true);
+        shadow_paint.set_mask_filter(skia::MaskFilter::blur(
+            skia::BlurStyle::Normal,
+            12.5,
+            false,
+        ));
+        surface
+            .canvas()
+            .draw_round_rect(shadow_rect, border_radius, border_radius, &shadow_paint);
+    }
+
+    // Backdrop
+    {
+        let mut bg_paint = skia::Paint::default();
+        bg_paint.set_color(skia::Color::from_argb(25, 255, 255, 255));
+        bg_paint.set_anti_alias(true);
+        surface
+            .canvas()
+            .draw_round_rect(rect, border_radius, border_radius, &bg_paint);
+    }
+
+    surface.canvas().restore();
+
+    let image = surface.image_snapshot();
+
+    let mut composite_paint = skia::Paint::default();
+    composite_paint.set_blend_mode(skia::BlendMode::SrcOver);
+    canvas.draw_image(&image, (0.0, 0.0), Some(&composite_paint));
+
+    None
+}
+
+#[test]
+fn test_sw_transparency() {
+    init();
+
+    let pipeline = gst::Pipeline::new();
+
+    let mix = gst::ElementFactory::make("skiacompositor")
+        .name("mix")
+        .property_from_str("background", "Transparent")
+        .build()
+        .unwrap();
+    let videoconvert = gst::ElementFactory::make("videoconvert")
+        .build()
+        .unwrap();
+    let jpegenc = gst::ElementFactory::make("jpegenc").build().unwrap();
+    let filesink = gst::ElementFactory::make("filesink")
+        .property("location", "/tmp/sw_transparency_minimal.jpg")
+        .build()
+        .unwrap();
+
+    pipeline
+        .add_many([&mix, &videoconvert, &jpegenc, &filesink])
+        .unwrap();
+    gst::Element::link_many([&mix, &videoconvert, &jpegenc, &filesink])
+        .unwrap();
+
+    // Source 0: solid purple background
+    let bg_src = gst::ElementFactory::make("videotestsrc")
+        .property_from_str("pattern", "solid-color")
+        .property("foreground-color", 0xFFDED5F5u32)
+        .property("num-buffers", 1i32)
+        .build()
+        .unwrap();
+    let bg_capsfilter = gst::ElementFactory::make("capsfilter")
+        .property(
+            "caps",
+            &gst_video::VideoCapsBuilder::new()
+                .format(gst_video::VideoFormat::Rgba)
+                .width(320)
+                .height(240)
+                .framerate(gst::Fraction::new(1, 1))
+                .build(),
+        )
+        .build()
+        .unwrap();
+
+    pipeline.add_many([&bg_src, &bg_capsfilter]).unwrap();
+    gst::Element::link_many([&bg_src, &bg_capsfilter]).unwrap();
+
+    let bg_pad = mix.request_pad_simple("sink_%u").unwrap();
+    bg_pad.set_property("width", 320.0f32);
+    bg_pad.set_property("height", 240.0f32);
+    bg_capsfilter
+        .static_pad("src")
+        .unwrap()
+        .link(&bg_pad)
+        .unwrap();
+
+    // Source 1: transparent input → skiareshape with draw signal
+    let sub_src = gst::ElementFactory::make("videotestsrc")
+        .property_from_str("pattern", "solid-color")
+        .property("foreground-color", 0x00000000u32)
+        .property("num-buffers", 1i32)
+        .build()
+        .unwrap();
+    let sub_capsfilter = gst::ElementFactory::make("capsfilter")
+        .property(
+            "caps",
+            &gst_video::VideoCapsBuilder::new()
+                .format(gst_video::VideoFormat::Rgba)
+                .width(320)
+                .height(240)
+                .framerate(gst::Fraction::new(1, 1))
+                .build(),
+        )
+        .build()
+        .unwrap();
+    let reshape = gst::ElementFactory::make("skiareshape")
+        .name("reshape")
+        .build()
+        .unwrap();
+
+    pipeline
+        .add_many([&sub_src, &sub_capsfilter, &reshape])
+        .unwrap();
+    gst::Element::link_many([&sub_src, &sub_capsfilter, &reshape])
+        .unwrap();
+
+    let sub_pad = mix.request_pad_simple("sink_%u").unwrap();
+    sub_pad.set_property("width", 320.0f32);
+    sub_pad.set_property("height", 240.0f32);
+    reshape
+        .static_pad("src")
+        .unwrap()
+        .link(&sub_pad)
+        .unwrap();
+
+    reshape.connect("draw", false, draw_subtitle_backdrop);
+
+    pipeline
+        .set_state(gst::State::Playing)
+        .expect("Failed to set pipeline to Playing");
+
+    let bus = pipeline.bus().unwrap();
+    for msg in bus.iter_timed(gst::ClockTime::from_seconds(10)) {
+        match msg.view() {
+            gst::MessageView::Eos(..) => break,
+            gst::MessageView::Error(err) => {
+                eprintln!(
+                    "Error from {:?}: {} ({:?})",
+                    err.src().map(|s| s.path_string()),
+                    err.error(),
+                    err.debug()
+                );
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    pipeline
+        .set_state(gst::State::Null)
+        .expect("Failed to set pipeline to Null");
+
+    println!("Done — inspect /tmp/sw_transparency_minimal.jpg");
+}


### PR DESCRIPTION
Skia GPU surfaces always produce premultiplied alpha, but glvideomixer
expects straight (unpremultiplied) alpha for its default SrcOver blend.
This caused transparent areas to appear greyish when composited.

Fix by wrapping the render in a save_layer with a SkSL runtime shader
ImageFilter that divides RGB by alpha, combined with BlendMode::Src so
the layer restore writes straight-alpha values directly to the output
texture. The conversion runs entirely on the GPU within Skia's pipeline.