### PR TITLE
Fix asymmetric skiareshape crop caps

### DIFF
--- a/video/skia/src/reshape_common.rs
+++ b/video/skia/src/reshape_common.rs
@@ -30,6 +30,10 @@ pub struct Settings {
     pub disable_crop_optimization: bool,
 }
 
+fn cropped_extent(extent: i32, leading: i32, trailing: i32, padding: i32) -> i32 {
+    extent - leading - trailing + 2 * padding
+}
+
 impl Default for Settings {
     fn default() -> Self {
         Settings {
@@ -545,16 +549,24 @@ pub trait ReshapeCommon: BaseTransformImpl + ObjectImpl {
                             if let Ok(width) = structure.get::<i32>("width") {
                                 structure.set(
                                     "width",
-                                    width - settings.crop_left - settings.crop_right
-                                        + 2 * settings.padding_px,
+                                    cropped_extent(
+                                        width,
+                                        settings.crop_left,
+                                        settings.crop_right,
+                                        settings.padding_px,
+                                    ),
                                 );
                             }
 
                             if let Ok(height) = structure.get::<i32>("height") {
                                 structure.set(
                                     "height",
-                                    height - settings.crop_top - settings.crop_top
-                                        + 2 * settings.padding_px,
+                                    cropped_extent(
+                                        height,
+                                        settings.crop_top,
+                                        settings.crop_bottom,
+                                        settings.padding_px,
+                                    ),
                                 );
                             }
 
@@ -954,5 +966,16 @@ pub fn add_original_frame_meta(outbuf: &mut gst::BufferRef, inbuf: &gst::BufferR
     #[cfg(not(feature = "ges"))]
     {
         let _ = (outbuf, inbuf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cropped_extent;
+
+    #[test]
+    fn asymmetric_crop_uses_both_edges() {
+        assert_eq!(cropped_extent(1080, 0, 2, 0), 1078);
+        assert_eq!(cropped_extent(1080, 236, 4, 3), 846);
     }
 }


### PR DESCRIPTION
## Summary

- compute fallback output extents from both crop edges
- fix height negotiation using `crop_bottom` instead of subtracting `crop_top` twice
- cover asymmetric top/bottom crops with a focused regression test

## Root cause

`reshape_transform_caps` used `height - crop_top - crop_top` when `compute_output_size` could not resolve a fixed output. Production screen recordings commonly have `crop_top = 0` and a non-zero recorder trim at the bottom, so legacy GStreamer negotiated the untrimmed height while drawing the cropped source. That vertically rescales/displaces the layer relative to render_engine.

Prod-T4 cause-removal checks against saved legacy artifacts:

- card 16: SSIM `0.737017 -> 0.940135` when the new-engine probe removes only the bottom crop legacy ignored during caps negotiation
- card 17: `0.8693 -> 0.961953`
- card 18: `0.9395 -> 0.982853`

## Validation

- `cargo test --manifest-path video/skia/Cargo.toml asymmetric_crop_uses_both_edges --lib` on Jaap's prod Tesla T4: 1 passed
- `rustfmt --edition 2021 --check video/skia/src/reshape_common.rs`
- `git diff --check`